### PR TITLE
Release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Changelog
 ------------
 -
 
+[v1.1.2] - 2019-07-31
+---------------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.1.2)
+### Added
+- Option to show or hide rows in the crowns breakdown, that have no skills at 
+that level.
+
+### Changed
+- Added detection for IN BETA label at the top of beta trees so that the needs 
+strengthening list or skill suggestion will be shown below this now.
+- Options are now initially set to defauls and overwritten by the stored 
+values. This allows any new options to be set to on first use, then saved in 
+storage.
+
 [v1.1.1] - 2019-07-30
 ---------------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.1.1)
@@ -355,6 +369,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.1.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.1...v1.1.2
 [v1.1.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/ToranSharma/Duo-Strength/compare/v1.0.22...v1.1.0
 [v1.0.22]: https://github.com/ToranSharma/Duo-Strength/compare/v1.0.21...v1.0.22

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -646,6 +646,12 @@ function displayNeedsStrengthening(needsStrengthening, needsSorting = true)
 			margin-bottom 2em;
 			min-height: 3em;
 		`;
+		if (topOfTree.getElementsByClassName("_27CnM").length != 0)
+		{
+			// If there is the IN BETA label, make it relative, not aboslute.
+			topOfTree.getElementsByClassName("_27CnM")[0].style['position'] = 'relative';
+			strengthenBox.style['margin-top'] = "0.5em";
+		}
 	}
 	else
 	{
@@ -1267,7 +1273,12 @@ function displaySuggestion(skills, bonusSkills)
 		let container = document.createElement("div");
 		container.id = "fullStrengthMessageContainer";
 		container.style = "margin-bottom: 2em;";
-
+		if (topOfTree.getElementsByClassName("_27CnM").length != 0)
+		{
+			// If there is the IN BETA label, make it relative, not absolute.
+			topOfTree.getElementsByClassName("_27CnM")[0].style['position'] = 'relative';
+			container.style['margin-top'] = "0.5em";
+		}
 		let treeLevel = crownTreeLevel();
 		let skillsByCrowns = [[],[],[],[],[],[]];
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -42,6 +42,7 @@ function retrieveOptions()
 					"crownsInfo":						true,
 					"crownsMaximum":					true,
 					"crownsBreakdown":					true,
+					"crownsBreakdownShowZerosRows":		true,
 					"crownsPrediction":					true,
 					"XPInfo":							true,
 					"XPBreakdown":						true,
@@ -878,6 +879,10 @@ function displayCrownsBreakdown()
 		for(let crownLevel = 0; crownLevel < crownLevelCount[0].length; crownLevel++)
 		{
 			let skillCount = crownLevelCount[0][crownLevel];
+
+			if (!options.crownsBreakdownShowZerosRows && skillCount == 0)
+				continue;
+
 			let crownCount = skillCount * crownLevel;
 		
 			levelContainer.id = "crownLevel" + crownLevel + "Count";

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -27,10 +27,8 @@ function retrieveOptions()
 	{
 		chrome.storage.sync.get("options", function (data)
 		{
-			if (Object.entries(data).length === 0)
-			{
-				// First time using version with options so nothing is set in storage.
-				options =
+			// Set options to default settings
+			options =
 				{
 					"strengthBars":						true,
 					"strengthBarBackgrounds":			true, 
@@ -48,10 +46,21 @@ function retrieveOptions()
 					"XPBreakdown":						true,
 					"XPPrediction":						true
 				};
-				chrome.storage.sync.set({"options": options});
+			if (Object.entries(data).length === 0)
+			{
+				// First time using version with options so nothing is set in storage.
 			}
 			else
-				options = data.options;
+			{
+				// We have loaded some options,
+				// let's apply them individually in case new options have been added since last on the options page
+				for (option in data.options)
+				{
+					options[option] = data.options[option];
+				}
+			}
+			// Now let's save the options for next time.
+			chrome.storage.sync.set({"options": options});
 			resolve();
 		});
 	});

--- a/manifest.json
+++ b/manifest.json
@@ -24,12 +24,11 @@
 	"options_ui"		:	{
 		"page"			:	"options.html",
 		"open_in_tab"	:	false
-	}/*,
-
-	"browser_specific_settings": {
-		"gecko": {
-			"id": "{911cd95f-2518-40ca-b122-a3d26b0d727b}"
-		}
 	}
-	*/
+// 	,
+// 	"browser_specific_settings": {
+// 		"gecko": {
+// 			"id": "{911cd95f-2518-40ca-b122-a3d26b0d727b}"
+// 		}
+// 	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.1.1",
+	"version"			:	"1.1.2",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -27,7 +27,6 @@
 		
 			li > ul
 			{
-				/*padding-left: 1em;*/
 				grid-column: span 2;
 			}
 				li > ul > li
@@ -35,7 +34,7 @@
 					grid-template-columns: 3em 3em 1fr;
 					box-sizing: content-box;
 				}
-					li > ul > li:before
+					li > ul > li::before
 					{
 						content: "";
 						z-index: 1;
@@ -48,13 +47,28 @@
 						top: calc(-50% - 1px - 0.2em);
 						left: calc(50% - 0.5px);
 					}
-		li:nth-of-type(odd)
-		{
-			/*background-color: #DDD;*/
-		}
+					li > ul > li > ul
+					{
+						grid-column: 2 / span 2;
+					}
+					li > ul > li > ul::after
+					{
+						content: "";
+						z-index: 1;
+						height: 50%;
+						width: 1em;
+						border-style: dashed;
+						border-color: black;
+						border-width: 0px 0px 0px 1px;
+						position: absolute;
+						top: calc(25% - 2px);
+						left: calc(1.5em - 0.5px);
+						grid-column: 1;
+					}
+
 		input
 		{
-			z-index: 2;
+			z-index: 3;
 		}
 		input[type="checkbox"]
 		{
@@ -78,7 +92,7 @@
 			}
 		select
 		{
-			z-index: 2;
+			z-index: 3;
 			box-sizing: border-box;
 			width: fit-content;
 		}
@@ -91,6 +105,7 @@
 			position: absolute;
 			grid-column-start: 1;
 			left: calc(3.5em + 1px);
+			top: 0.05em;
 			box-shadow: inset 0px 0px 0 20px white;
 		}
 		button
@@ -161,6 +176,13 @@
 					<input class="dummy" type="checkbox" />
 					<input class="option" id="crownsBreakdown" type="checkbox" checked="true" />
 					<label for="crownsBreakdown">Crowns Breakdown</label>
+					<ul>
+						<li>
+							<input class="dummy" type="checkbox" />
+							<input class="option" id="crownsBreakdownShowZerosRows" type="checkbox" checked="true;">
+							<label for="crownsBreakdownShowZerosRows">Show rows with zero skills</label>
+						</li>
+					</ul>
 				</li>
 				<li>
 					<input class="dummy" type="checkbox" />

--- a/options.html
+++ b/options.html
@@ -105,7 +105,7 @@
 			position: absolute;
 			grid-column-start: 1;
 			left: calc(3.5em + 1px);
-			top: 0.05em;
+			top: 1.5px;
 			box-shadow: inset 0px 0px 0 20px white;
 		}
 		button
@@ -123,7 +123,7 @@
 			<label for="strengthBars">Strength Bars</label>
 			<ul>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="strengthBarBackgrounds" type="checkbox" checked="true" />
 					<label for="needsStrengtheningListLength">Grey background showing width of a full bar</label>
 				</li>
@@ -168,24 +168,24 @@
 			<label for="crownsInfo">Additional Crowns Information</label>
 			<ul>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="crownsMaximum" type="checkbox" checked="true" />
 					<label for="crownsMaximum">Crowns Maximum</label>
 				</li>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="crownsBreakdown" type="checkbox" checked="true" />
 					<label for="crownsBreakdown">Crowns Breakdown</label>
 					<ul>
 						<li>
-							<input class="dummy" type="checkbox" />
+							<input class="dummy" type="checkbox" disabled="true" />
 							<input class="option" id="crownsBreakdownShowZerosRows" type="checkbox" checked="true;">
 							<label for="crownsBreakdownShowZerosRows">Show rows with zero skills</label>
 						</li>
 					</ul>
 				</li>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="crownsPrediction" type="checkbox" checked="true" />
 					<label for="crownsPrediction">Crowns Prediction</label>
 				</li>
@@ -196,12 +196,12 @@
 			<label for="XPInfo">Additional XP Info</label>
 			<ul>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="XPBreakdown" type="checkbox" checked="true" />
 					<label for="XPBreakdown">XP Breakdown</label>
 				</li>
 				<li>
-					<input class="dummy" type="checkbox" />
+					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="XPPrediction" type="checkbox" checked="true" />
 					<label for="XPPrediction">XP Prediction</label>
 				</li>


### PR DESCRIPTION
Added detection and handling of the IN BETA label at the top of beta trees which was obscuring. Needs Strengthening list and skill suggestion are now shown below this label.

Added a new option to hide rows in the crowns breakdown that have zero skills at that level. Changed the loading of the options to handle new options that don't have a value stored. Options are now set to the default values before being overwritten by the value stored. This way any new options have a value set, the default one. Options are then stored after loading to save any new options.