### PR TITLE
Hotfix 1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Changelog
 [Unreleased]
 ------------
 -
+[v1.1.10] - 2019-09-21
+----------------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.1.10)
+### Fixed
+- Page change detection has been updated to include addition checks which 
+allow for the current lack of the active tab class being applied to the 
+learn tab. This is expected to be added back by duolingo so the current 
+detection methods using class name changes on the learn tab.
 
 [v1.1.9] - 2019-09-08
 ---------------------
@@ -16,7 +24,8 @@ class name defined in `SKILL_CONTAINER`. Similarly the icon element is
 selected by class name, not its relative relation to the container element.
 
 ### Fixed
-- Fixed display suggestion to correctly try again after a wait if the page hasn't loaded fully yet.
+- Fixed display suggestion to correctly try again after a wait if the page 
+hasn't loaded fully yet.
 
 [v1.1.8] - 2019-09-06
 ---------------------
@@ -447,6 +456,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.1.10]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.9...v1.1.10
 [v1.1.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.8...v1.1.9
 [v1.1.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.7...v1.1.8
 [v1.1.7]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.6...v1.1.7

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -45,6 +45,7 @@ let requestID = 0;
 let rootElem;
 let rootChild;
 let mainBody;
+let mainBodyContainer;
 let topBarDiv;
 let mobileTopBarDiv;
 
@@ -1764,6 +1765,16 @@ let childListMutationHandle = function(mutationsList, observer)
 				// we have just entered a lesson in the normal way and we don't need to do anything.
 			}
 		}
+		else if (mutation.target == mainBodyContainer)
+		{
+			// mainBodyContainer childlist changed, so the mainBody element must have been replaced.
+			mainBody = mainBodyContainer.firstChild;
+
+
+			// This mainBody element being replaced happens on some page changes, so let's also trigger some page change checks
+
+			classNameMutationHandle(mutationsList, null);
+		}
 		else if (mutation.target == mainBody)
 		{
 			// Switched between mobile and desktop layouts.
@@ -1904,7 +1915,7 @@ let classNameMutationHandle = function(mutationsList, observer)
 		// Just in case there is also a language change still going on we won't set languageChanged to false.
 
 		// check if we are now on the main page
-		if (topBarDiv.childNodes[0].className.includes(ACTIVE_TAB))
+		if (topBarDiv.childNodes[0].className.includes(ACTIVE_TAB) || window.location.pathname == "/learn")
 		{
 			// on main page
 			// check if language has been previously set as we only set it in init if we were on the main page
@@ -1944,9 +1955,12 @@ async function init()
 	childListObserver.observe(rootElem,{childList: true}); // Observing for changes to its children to detect logging in and out?
 	childListObserver.observe(rootChild,{childList: true}); // Observing for changes to its children to detect entering and leaving a lesson.
 	
-	mainBody = rootChild.lastChild.firstChild;
+	mainBodyContainer = rootChild.lastChild;
+	mainBody = mainBodyContainer.firstChild;
+	
+	childListObserver.observe(mainBodyContainer, {childList:true}); // Observing for changes to its children to detect if the mainBody element has been replaced.
 	childListObserver.observe(mainBody,{childList:true}); // Observing for changes to its children to detect moving between mobile and desktop layout.
-
+	
 	if (mainBody.getElementsByClassName(SIDEBAR).length == 0)
 		inMobileLayout = true;
 	else
@@ -2025,14 +2039,15 @@ async function init()
 			/* unused/unusable
 			classNameObserver.observe(discussionNav,{attributes: true}); // Observing to see if class of discussionNav changes to tell if we have switched to or from discussion page. Though the extension does not handle this domain due to forums subdomain prefix.
 			*/
-			//classNameObserver.observe(shopNav,{attributes: true}); // Observing to see if class of shopNav changes to tell if we have switched to or from the shop.
+			classNameObserver.observe(shopNav,{attributes: true}); // Observing to see if class of shopNav changes to tell if we have switched to or from the shop.
 
 			// set up observers for crown and streak nav hovers
 			childListObserver.observe(crownNav.lastChild,{childList: true}); // Observing to see if pop-up box is created showing crown data.
 			childListObserver.observe(streakNav.lastChild,{childList: true}); // Observing to see if pop-up box is created showing streak and XP data.
 
-			if (homeNav.className.includes(ACTIVE_TAB))
+			if (homeNav.className.includes(ACTIVE_TAB) || window.location.pathname == "/learn")
 			{
+				// Seems as though the main page is now at /learn and the tab is not active, but we leave the check in case
 				// on home page
 				onMainPage = true;
 			}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.1.9",
+	"version"			:	"1.1.10",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{


### PR DESCRIPTION
The `ACTIVE_TAB` class is no longer being applied to the main (learn) tab. Instead the url now ends with `/learn`. To account for this change, additional checks have been added which check the url as well as detection of the replacement of the `mainBody` element. These new methods capture most of the page changes that were previously caught by the change of the `ACTIVE_TAB` class name.