### PR TITLE
Hotfix 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.0)
 ### Added
 - New option to disable the focusing of the first skill in lists. This is added
-to combat the auto scrolling into view of the lists when reentereing the tree
+to combat the auto scrolling into view of the lists when reentering the tree
 from a lesson.
+
+### Changed
+- Changing between word bank and keyboard input on a translation question is now
+detected and the sentence is hidden after the swtich.
 
 [v1.2.0] - 2020-01-09
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog
 
 [v1.2.1] - 2020-01-10
 -----------------
-[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.0)
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.1)
 ### Added
 - New option to disable the focusing of the first skill in lists. This is added
 to combat the auto scrolling into view of the lists when reentering the tree
@@ -15,7 +15,9 @@ from a lesson.
 
 ### Changed
 - Changing between word bank and keyboard input on a translation question is now
-detected and the sentence is hidden after the swtich.
+detected and the sentence is hidden after the switch.
+- Enable/disable text hiding button is now floated according to the language text
+direction, right for LTR and left for RTL.
 
 [v1.2.0] - 2020-01-09
 -----------------
@@ -525,6 +527,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.2.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.0...v1.2.1
 [v1.2.0]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.12...v1.2.0
 [v1.1.12]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.11...v1.1.12
 [v1.1.11]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.10...v1.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Changelog
 
 [Unreleased]
 ------------
+-
+
+[v1.2.1] - 2020-01-10
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.0)
+### Added
+- New option to disable the focusing of the first skill in lists. This is added
+to combat the auto scrolling into view of the lists when reentereing the tree
+from a lesson.
 
 [v1.2.0] - 2020-01-09
 -----------------

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2233,7 +2233,6 @@ function hideTranslationText(reveal = false, setupObserver = true)
 					enableDisableButton.style =
 					`
 						color: white;
-						float: right;
 						border: 0;
 						border-radius: 0.5em;
 						padding: 0.4em;
@@ -2263,6 +2262,17 @@ function hideTranslationText(reveal = false, setupObserver = true)
 						hideTranslationText();
 					};
 
+					if (challengeTranslatePrompt.dir == "ltr")
+					{
+						// LTR language, button goes to the right
+						enableDisableButton.style.float = "right";
+					}
+					else
+					{
+						// RTL language, button goes to the left
+						enableDisableButton.style.float = "left";
+					}
+					
 					hintSentence.parentNode.insertBefore(enableDisableButton, hintSentence.nextSibling);
 				}
 				else

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -83,6 +83,7 @@ function retrieveOptions()
 					"crackedSkillsList":				true,
 					"crackedSkillsListLength":			"10",
 					"crackedSkillsListSortOrder":		"0",
+					"focusFirstSkill":					true,
 					"skillSuggestion":					true,
 					"skillSuggestionMethod":			"0",
 					"crownsInfo":						true,
@@ -1081,7 +1082,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 		topOfTree.appendChild(strengthenBox);
 	}
 
-	firstSkillLink.focus();
+	if (options.focusFirstSkill) firstSkillLink.focus();
 }
 
 function getCrackedSkills()
@@ -1915,7 +1916,7 @@ function displaySuggestion(skills, bonusSkills)
 
 		topOfTree.appendChild(container);
 
-		link.focus();
+		if (options.focusFirstSkill) link.focus();
 	}
 	else
 	{

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2181,7 +2181,7 @@ function checkUIVersion()
 }
 */
 
-function hideTranslationText(reveal = false)
+function hideTranslationText(reveal = false, setupObserver = true)
 {
 	if (document.getElementsByClassName(QUESTION_CONTAINER).length == 0)
 		return false;
@@ -2196,7 +2196,11 @@ function hideTranslationText(reveal = false)
 		if (challengeTranslatePrompt.querySelectorAll("BUTTON").length != 0)
 		{
 			// There is an svg in the question sentence which is the speaker button so we are translating from the target to the native language
+			const questionArea = questionContainer.firstChild.firstChild;
+			if (setupObserver) childListObserver.observe(questionArea, {childList: true});
+			
 			const hintSentence = challengeTranslatePrompt.querySelector('[data-test="hint-sentence"]');
+			
 
 			if (hintSentence.querySelectorAll(NEW_WORD_SELECTOR).length != 0)
 				return false; // There is a new word, so we don't want to be hiding this sentence.
@@ -2290,6 +2294,7 @@ let childListMutationHandle = function(mutationsList, observer)
 	let popupIcon;
 	let lessonLoaded = false;
 	let lessonQuestionChanged = false;
+	let lessonInputMethodChanged = false;
 	
 	for (let mutation of mutationsList)
 	{
@@ -2310,6 +2315,8 @@ let childListMutationHandle = function(mutationsList, observer)
 			lessonLoaded = true;
 		else if (mutation.target.parentNode.className == LESSON_MAIN_SECTION && mutation.addedNodes.length != 0)
 			lessonQuestionChanged = true;
+		else if (mutation.target.parentNode.parentNode.className.includes(QUESTION_CONTAINER))
+			lessonInputMethodChanged = true;
 	}
 
 	if (rootChildReplaced)
@@ -2452,6 +2459,7 @@ let childListMutationHandle = function(mutationsList, observer)
 		// Set up mutation observer for question change
 		childListObserver.observe(document.getElementsByClassName(LESSON_MAIN_SECTION)[0].firstChild, {childList:true});
 		
+		
 		// Set up mutation observer for question checked status change
 		const lessonBottomSection = document.getElementsByClassName(LESSON_BOTTOM_SECTION)[0];
 		classNameObserver.observe(lessonBottomSection.firstChild, {attributes: true});
@@ -2461,6 +2469,12 @@ let childListMutationHandle = function(mutationsList, observer)
 		// Run check for translation type question
 
 		hideTranslationText();
+	}
+	if (lessonInputMethodChanged)
+	{
+		// Need to re run question hiding as the question box has been replaced.
+
+		hideTranslationText(undefined, false);
 	}
 };
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.2.0",
+	"version"			:	"1.2.1",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -170,6 +170,10 @@
 			</ul>
 		</li>
 		<li>
+			<input class="option" id="focusFirstSkill" type="checkbox" checked="true" />
+			<label for="focusFirstSkill">Focus First Skill in Lists</label>
+		</li>
+		<li>
 			<input class="option" id="skillSuggestion" type="checkbox" checked="true" />
 			<label for="skillSuggestion">Fully Strengthened Tree Skill Suggestion</label>
 			<ul>


### PR DESCRIPTION
New option to disable the focusing of the first skill in lists. This is added
to combat the auto scrolling into view of the lists when reentering the tree
from a lesson.

Changing between word bank and keyboard input on a translation question is now
detected and the sentence is hidden after the switch.

Enable/disable text hiding button is now floated according to the language text
direction, right for LTR and left for RTL.