### PR TITLE
Hotfix 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog
 ### Fixed
 - Detection of left to right, or right to left sentences in translation
 questions.
+- Classname for top of tree element. Old classname retained in case not all
+users have this change.
 
 [v1.2.1] - 2020-01-10
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.2.2] - 2020-01-21
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.1)
+### Fixed
+- Detection of left to right, or right to left sentences in translation
+questions.
+
 [v1.2.1] - 2020-01-10
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.1)
@@ -527,6 +534,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.2.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.1...v1.2.2
 [v1.2.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.0...v1.2.1
 [v1.2.0]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.12...v1.2.0
 [v1.1.12]: https://github.com/ToranSharma/Duo-Strength/compare/v1.1.11...v1.1.12

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2262,7 +2262,10 @@ function hideTranslationText(reveal = false, setupObserver = true)
 						hideTranslationText();
 					};
 
-					if (challengeTranslatePrompt.dir == "ltr")
+					if (
+						challengeTranslatePrompt.dir == "ltr" ||
+						challengeTranslatePrompt.firstChild.dir == "ltr"
+					)
 					{
 						// LTR language, button goes to the right
 						enableDisableButton.style.float = "right";

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -14,6 +14,7 @@ const BONUS_SKILL_DIVIDER = "_32Q0j";
 const TREE_CONTAINER = "i12-l";
 const TOP_OF_TREE_WITH_IN_BETA = "w8Lxd";
 const TOP_OF_TREE = "_3rABk";
+const TOP_OF_TREE_NEW = "iIzBH";
 const MOBILE_TOP_OF_TREE = "_3UShd";
 const SKILL_ROW = "_2GJb6";
 const SKILL_COLUMN = "QmbDT";
@@ -809,6 +810,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			document.getElementsByClassName(SKILL_ROW).length != 0 &&
 			(
 				document.getElementsByClassName(TOP_OF_TREE).length != 0 ||
+				document.getElementsByClassName(TOP_OF_TREE_NEW).length != 0 ||
 				document.getElementsByClassName(MOBILE_TOP_OF_TREE).length != 0 ||
 				document.getElementsByClassName(TOP_OF_TREE_WITH_IN_BETA).length != 0
 			)
@@ -1752,6 +1754,7 @@ function displaySuggestion(skills, bonusSkills)
 			document.getElementsByClassName(SKILL_ROW).length != 0 &&
 			(
 				document.getElementsByClassName(TOP_OF_TREE).length != 0 ||
+				document.getElementsByClassName(TOP_OF_TREE_NEW).length != 0 ||
 				document.getElementsByClassName(MOBILE_TOP_OF_TREE).length != 0 ||
 				document.getElementsByClassName(TOP_OF_TREE_WITH_IN_BETA).length != 0
 			)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.2.1",
+	"version"			:	"1.2.2",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{


### PR DESCRIPTION
Enable/Disable text hiding button was misaligned due to added container element to question text which now contains the dir information. This new container is now checked (as well as the parent) for dir information to guide the float style of the button.

The topOfTree element's class name had been changed, this has been added as a new version to check along side the old in case of some users still having the old class name.