### PR TITLE
Hotfix 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ Changelog
 ------------
 -
 
-[v1.2.4] - 2020-02-20
+[v1.2.6] - 2020-02-20
 -----------------
-[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.4)
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.6)
+### Fixed
+- Links in lists at the top of the page are now clickable in mobile layout. The
+container element for the lists at the top of the page is now forced to be on
+top of the skill tree if they are overlapping. This means that the click
+events are handled by the links now the skill tree.
+
+[v1.2.5] - 2020-02-20
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.5)
 ### Fixed
 - Crowns progress retrieval on first load.
 
@@ -570,6 +579,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.2.6]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.5...v1.2.6
 [v1.2.5]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.4...v1.2.5
 [v1.2.4]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.3...v1.2.4
 [v1.2.3]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.2...v1.2.3

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -901,9 +901,14 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 				shuffle(needsStrengthening[1]);
 				break;
 		}
-
-	topOfTree.style.height = "auto";
-	topOfTree.style.width = "100%";
+	
+	topOfTree.style =
+	`
+		height: auto;
+		width: 100%;
+		z-index: 2;
+	`;
+	topOfTree.nextElementSibling.style = `z-index: 1`;
 
 	let strengthenBox = document.getElementById((!cracked)?"strengthenBox":"crackedBox"); // will be a div to hold list of skills that need strengthenening
 	let needToAddBox = false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.2.5",
+	"version"			:	"1.2.6",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{


### PR DESCRIPTION
Fix overlapping `topOfTree` element with skill tree. `topOfTree` is now given higher z-index so that links in lists are clickable.