### PR TITLE
Issue #51 fix - Skill popout box not clickable near bottom of page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog
 ------------
 -
 
+[v1.2.8] - 2020-03-25
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.8)
+### Fixed
+- Fix for GitHub issue 51, where skill popout bubbles could not be interacted
+with when they were inline with the global practice button at the bottom of the
+page in desktop view.
+
 [v1.2.7] - 2020-03-01
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.7)
@@ -585,6 +593,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.2.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.7...v1.2.7
 [v1.2.7]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.6...v1.2.7
 [v1.2.6]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.5...v1.2.6
 [v1.2.5]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.4...v1.2.5

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -906,9 +906,8 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 	`
 		height: auto;
 		width: 100%;
-		z-index: 2;
+		z-index: 1;
 	`;
-	topOfTree.nextElementSibling.style = `z-index: 1`;
 
 	let strengthenBox = document.getElementById((!cracked)?"strengthenBox":"crackedBox"); // will be a div to hold list of skills that need strengthenening
 	let needToAddBox = false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.2.7",
+	"version"			:	"1.2.8",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{


### PR DESCRIPTION
Small fix to solve issue #51. Skill popout boxes were being displayed underneath the container element for the global practice button at the bottom of the page when in desktop layout. This stopped any buttons that were under this invisible box from being able to be clicked on.