### PR TITLE
Hotfix 1.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ Changelog
 ------------
 -
 
+[v1.2.11] - 2020-03-31
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.11)
+### Fixed
+- Classname for bonus skill dividing lines. This fixes the adding of strength 
+bars on trees with bonus skills.
+
 [v1.2.10] - 2020-03-30
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.2.10)
 ### Fixed
-- Class name for new words in lessons. Detection of new words is now fixed so 
+- Classname for new words in lessons. Detection of new words is now fixed so 
 that sentences with new words are never hidden.
 
 [v1.2.9] - 2020-03-30
@@ -607,6 +614,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.2.11]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.10...v1.2.11
 [v1.2.10]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.9...v1.2.10
 [v1.2.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.8...v1.2.9
 [v1.2.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.2.7...v1.2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 ### Fixed
 - Classname for bonus skill dividing lines. This fixes the adding of strength 
 bars on trees with bonus skills.
+- Show more link at end of lists briefly showing twice after a page change.
 
 [v1.2.10] - 2020-03-30
 -----------------

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -6,7 +6,7 @@ const DARK_BLUE = "rgb(24, 153, 214)";
 const LIGHT_BLUE = "rgb(28, 176, 246)";
 
 // Duolingo class names:
-const BONUS_SKILL_DIVIDER = "_32Q0j";
+const BONUS_SKILL_DIVIDER = "_23P6X";
 const TOP_OF_TREE_WITH_IN_BETA = "_1uUHs _3tYmC";
 const TOP_OF_TREE = "_3GFex";
 const MOBILE_TOP_OF_TREE = "_3Y5Xu";

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1038,8 +1038,16 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 	 	chrome.storage.sync.get("options", function (data)
 	 	{
 			let numExtraSkillsOnShowMore = Math.min(numSkillsLeft, (!cracked)?data.options.needsStrengtheningListLength:data.options.crackedSkillsListLength);
+			
+			let showMore = document.getElementById(`showMore${(!cracked)?"ToStrengthen":"ToRepair"}`);
+			if (showMore != null)
+			{
+				showMore.previousSibling.remove();
+				showMore.remove(); // could have updated the list before we got the data back, so if there is an existing showMore button then remove it and replace it with a newer one
+			}
 
-			let showMore = document.createElement("a");
+			showMore = document.createElement("a");
+			showMore.id = `showMore${(!cracked)?"ToStrengthen":"ToRepair"}`;
 			showMore.textContent = numSkillsLeft + " more...";
 			showMore.href = "";
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.2.10",
+	"version"			:	"1.2.11",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{


### PR DESCRIPTION
Updates bonus skill divider classname that was missed in v1.2.9 and v1.2.10, as reported in #55.

Makes a small change where the show more button on lists are removed if they already exist at the time of adding in case of new information. Previously on some page changes there could be two show more buttons added due to timings of getting values out of storage.