### PR TITLE
Hotfix 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog
 ### Fixed
 - Practise Button removed from bonus skills as they are either L0 so unfinished
 or L1 and golden where only practising is possible.
+- Practise Button and Words Button response to options update while popup is
+displayed.
 
 [v1.3.3] - 2020-04-13
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 or L1 and golden where only practising is possible.
 - Practise Button and Words Button response to options update while popup is
 displayed.
+- Enable/Disable Text Hiding button width to be consistent across browsers.
 
 [v1.3.3] - 2020-04-13
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.3.4] - 2020-04-15
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.4)
+### Fixed
+- Practise Button removed from bonus skills as they are either L0 so unfinished
+or L1 and golden where only practising is possible.
+
 [v1.3.3] - 2020-04-13
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.3)
@@ -716,6 +723,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.4]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.3...v1.3.4
 [v1.3.3]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.2...v1.3.3
 [v1.3.2]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.1...v1.3.2
 [v1.3.1]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.0...v1.3.1

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1761,12 +1761,14 @@ function addPractiseButton(skillPopout)
 	if (skillPopout == null)
 		return false;
 	
-	if (document.querySelector(SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR) == null)
-		return false;
+	const levelContainer = document.querySelector(SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR);
+	if (levelContainer == null)
+		return false; // Locked skill so don't do anything
 
-	const skillLevel = document.querySelector(SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR).textContent.slice(-3,-2);
-	if (skillLevel == 5 || skillLevel == 0)
-		return false;
+	const skillLevel = levelContainer.textContent.slice(-3,-2);
+	const maxLevel = levelContainer.textContent.slice(-1);
+	if (skillLevel === maxLevel || skillLevel === "0")
+		return false; // Skill is at max level so only practising is possible
 
 	const startButton = document.querySelector(`[data-test="start-button"]`);
 	startButton.textContent = "START LESSON";

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -346,6 +346,15 @@ function removeLanguagesInfo()
 		languagesInfoBox.parentNode.removeChild(languagesInfoBox);
 }
 
+function removePractiseButton()
+{
+	const practiseButton = document.querySelector(`[data-test="practise-button"]`);
+	if (practiseButton != null)
+	{
+		practiseButton.remove();
+	}
+}
+
 function removeWordsButton()
 {
 	const wordsButton = document.querySelector(`[data-test="words-button"]`);
@@ -3166,6 +3175,7 @@ function addFeatures()
 			{
 				if (options.practiseButton && skillPopout.querySelector(`[data-test="practise-button"]`) == null)
 				{
+					// Want practise button and there isn't one.
 					const introLesson = document.querySelector(`[data-test="intro-lesson"]`);
 					if (introLesson == null || !introLesson.contains(skillPopout))
 					{
@@ -3173,13 +3183,20 @@ function addFeatures()
 						addPractiseButton(skillPopout);
 					}
 				}
+				else if (!options.practiseButton && skillPopout.querySelector(`[data-test="practise-button"`) != null)
+				{
+					// Don't want practise button but there is one. 
+					removePractiseButton();
+				}
 
 				if (options.wordsButton && skillPopout.querySelector(`[data-test="words-button"]`) == null)
 				{
+					// Want words button and there isn't one
 					addWordsButton(skillPopout);
 				}
-				else
+				else if(!options.wordsButton && skillPopout.querySelector(`[data-test="words-button"]`) != null)
 				{
+					// Don't want words button, but there is one.
 					removeWordsButton();
 				}
 			}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -3526,7 +3526,7 @@ function hideTranslationText(reveal = false, setupObserver = true)
 					`;
 
 					const questionHeader = questionContainer.querySelector(`[data-test="challenge-header"]`);
-					questionHeader.style.width = `fit-content`;
+					questionHeader.style.width = `max-content`;
 					questionHeader.parentNode.insertBefore(headerContainer, questionHeader);
 					headerContainer.appendChild(questionHeader);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.3",
+	"version"			:	"1.3.4",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -123,7 +123,7 @@
 		}
 		.hasSelect
 		{
-			grid-template-columns: 3em fit-content(100%) 1fr;
+			grid-template-columns: 3em max-content 1fr;
 		}
 			.hasSelect > label
 			{
@@ -136,7 +136,7 @@
 		}
 		.selectFirst
 		{
-			grid-template-columns: fit-content(100%) 1fr;
+			grid-template-columns: max-content 1fr;
 		}
 			.selectFirst > label
 			{
@@ -144,7 +144,7 @@
 			}
 		.labelFirst
 		{
-			grid-template-columns: 3em fit-content(calc(100% - 6em)) 3em;
+			grid-template-columns: 3em max-content 3em;
 		}
 			.labelFirst > label
 			{
@@ -194,7 +194,7 @@
 			font-size: 100%;
 			z-index: 3;
 			box-sizing: border-box;
-			width: fit-content;
+			width: max-content;
 		}
 		select:disabled
 		{
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.3</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.4</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>

--- a/scripts/newversion
+++ b/scripts/newversion
@@ -47,7 +47,7 @@ git checkout $PARENTBRANCH
 git checkout -b "$BRANCHTYPE-$VERNUM"
 
 sed -i -b "/\"version\"/ s/$OLDVERNUM/$VERNUM/" manifest.json
-sed -b -b "/id=\"version\"/ s/$OLDVERNUM/$VERNUM/" options.html
+sed -i -b "/id=\"version\"/ s/$OLDVERNUM/$VERNUM/" options.html
 
 git add manifest.json
 git commit -m "Increment version number to $VERNUM"


### PR DESCRIPTION
Practise Button removed from bonus skills, see #57.
Fixed Practise Button and Words Button response to options update while popup is
displayed.
Removed all instances of the CSS width value fit-content and replaced with max-content to be compatible with Firefox. This makes the Enable/Disable Text Hiding button width consistent across browsers.