### PR TITLE
Hotfix 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.3.5] - 2020-04-18
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.5)
+### Changed
+- Skill popout is opened and then centred in the view when the tree is loaded
+after clicking the practise button.
+
 [v1.3.4] - 2020-04-15
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.4)
@@ -726,6 +733,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.5]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.4...v1.3.5
 [v1.3.4]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.3...v1.3.4
 [v1.3.3]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.2...v1.3.3
 [v1.3.2]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.1...v1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog
 - Skill popout is opened and then centred in the view when the tree is loaded
 after clicking the practise button.
 
+### Fixed
+- Checkpoint redo buttons added to congratulation message shown when the golden
+owl which replaces the last checkpoint is clicked on.
+
 [v1.3.4] - 2020-04-15
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 ### Changed
 - Skill popout is opened and then centred in the view when the tree is loaded
 after clicking the practise button.
+- Skill selector to only choose skills that are children of a tree section.
+This removes a conflict with
+[DuolingoNextLesson userscript](https://github.com/camiloaa/duolingonextlesson).
 
 ### Fixed
 - Checkpoint redo buttons added to congratulation message shown when the golden

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -49,6 +49,7 @@ const SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR = ".vwODZ";
 const SKILL_NAME_SELECTOR = "._2CXf4";
 const CHECKPOINT_CONTAINER_SELECTOR = "._3Lrsa";
 const CHECKPOINT_POPOUT_SELECTOR = "._15Wh7._6gtoB";
+const CHECKPOINT_BLURB_SELECTOR = "._3-EWe";
 const LANGUAGES_LIST_SELECTOR = "._2-Lx6";
 const SMALL_BUTTONS_CONTAINER = "_2DR3u";
 const SMALL_BUTTON = "_32WtB _2i-mO _1LZ7U vy3TL _3iIWE _1Mkpg _1Dtxl _1sVAI sweRn _1BWZU _26exN QVrnU";
@@ -1851,20 +1852,31 @@ function addPractiseButton(skillPopout)
 	skillPopout.scrollIntoView({block: "center"});
 }
 
-function addCheckpointButtons(checkpointPopout)
+function addCheckpointButtons(checkpointPopout, completedMessage = false)
 {
 	if (checkpointPopout == null)
 		return false;
 
-	if (checkpointPopout.querySelector(`[data-test="checkpoint-start-button"]`) != null)
+	if (!completedMessage && checkpointPopout.querySelector(`[data-test="checkpoint-start-button"]`) != null)
 		return false;
 
-	const checkpointNumber = Array.from(document.querySelectorAll(CHECKPOINT_CONTAINER_SELECTOR)).indexOf(checkpointPopout.parentNode);
-	popoutContent = checkpointPopout.firstChild.firstChild;
+	let checkpointNumber;
+	if (!completedMessage)
+	{
+		checkpointNumber = Array.from(document.querySelectorAll(CHECKPOINT_CONTAINER_SELECTOR)).indexOf(checkpointPopout.parentNode);
+		popoutContent = checkpointPopout.firstChild.firstChild;
+	}
+	else
+	{
+		// CHECKPOINT_CONTAINER_SELECTOR only selects completed checkpoint castles and not the golden owl
+		// so the last checkpoint in this case is one more than last checkpoint.
+		checkpointNumber = document.querySelectorAll(CHECKPOINT_CONTAINER_SELECTOR).length;
+		popoutContent = checkpointPopout;
+	}
 
 	oml = function ()
 	{
-		this.style.boxShadow = `0 0.25em rgba(255, 255, 255, 0.5)`;
+		this.style.boxShadow = `0 0.25em ${(!completedMessage) ? "rgba(255, 255, 255, 0.5)" : "grey"}`;
 		this.style.transform = "none";
 	};
 	omd = function ()
@@ -1874,7 +1886,7 @@ function addCheckpointButtons(checkpointPopout)
 	};
 	omu = function ()
 	{
-		this.style.boxShadow = `0 0.25em rgba(255, 255, 255, 0.5)`;
+		this.style.boxShadow = `0 0.25em ${(!completedMessage) ? "rgba(255, 255, 255, 0.5)" : "grey"}`;
 		this.style.transform = "none";
 	};
 
@@ -1895,6 +1907,23 @@ function addCheckpointButtons(checkpointPopout)
 		transition: filter 0.2s;
 		cursor: pointer;
 	`;
+
+
+	if (completedMessage)
+	{
+		redoTestButton.style.border = `2px solid grey`;
+		redoTestButton.style.color = "grey";
+		redoTestButton.style.backgroundColor = GOLD;
+		redoTestButton.style.width = "75%";
+		redoTestButton.style.alignSelf = "center";
+		redoTestButton.style.boxShadow = `0 0.25em grey`;
+
+		popoutContent.style.padding = "0 0 0.5em 0"
+	}
+	else if (checkpointPopout.querySelector(CHECKPOINT_BLURB_SELECTOR) == null)
+	{
+		popoutContent.style.width = "300px";
+	}
 
 	redoTestButton.addEventListener("mouseleave", oml);
 	redoTestButton.addEventListener("mousedown", omd);
@@ -3653,6 +3682,7 @@ let childListMutationHandle = function(mutationsList, observer)
 {
 	let rootChildReplaced = false;
 	let rootChildContentsReplaced = false;
+	let rootChildRemovedNodes = [];
 	let mainBodyReplaced = false
 	let sidebarToggled = false;
 	let popupChanged = false;
@@ -3671,7 +3701,10 @@ let childListMutationHandle = function(mutationsList, observer)
 		if (mutation.target == rootElem)
 			rootChildReplaced = true;
 		else if (mutation.target == rootChild)
+		{
 			rootChildContentsReplaced = true;
+			rootChildRemovedNodes = rootChildRemovedNodes.concat(Array.from(mutation.removedNodes));
+		}
 		else if (mutation.target == mainBodyContainer)
 			mainBodyReplaced = true;
 		else if (
@@ -3734,19 +3767,43 @@ let childListMutationHandle = function(mutationsList, observer)
 	}
 	else if (rootChildContentsReplaced)
 	{
-		// Check if there is both the topbar and the main page elem.
-		if (rootChild.childElementCount == 2)
+		if (
+			rootChildRemovedNodes.find(
+				(node) => {
+					return node.querySelector(`[src$="trophy.svg"]`) != null;
+				}
+			) != null
+		)
 		{
-			// not just changed into a lesson
-			languageChanged = false;
-			init();
+			// The trophy image was the descendant of one of the removed nodes.
+			// Don't need to do anything.
 		}
 		else
 		{
-			// Entered a lesson in the normal way, through the skill tree.
-			// Need to set up observer on lessonMainSection for when the first question loads
+			// Check if there is both the topbar and the main page elem.
+			if (rootChild.childElementCount == 2)
+			{
+				// not just changed into a lesson
+				languageChanged = false;
+				init();
+			}
+			else if (rootChild.childElementCount == 1)
+			{
+				// Entered a lesson in the normal way, through the skill tree.
+				// Need to set up observer on lessonMainSection for when the first question loads
 
-			childListObserver.observe(document.getElementsByClassName(LESSON_MAIN_SECTION)[0], {childList:true});
+				childListObserver.observe(document.getElementsByClassName(LESSON_MAIN_SECTION)[0], {childList:true});
+			}
+			else 
+			{
+				const trophy = rootChild.querySelector(`[src$="trophy.svg"]`);
+				if (trophy != null)
+				{
+					// The golden owl has been clicked and the congratulation message is being displayed
+					const messageContainer = trophy.nextElementSibling;
+					addCheckpointButtons(messageContainer, true);
+				}
+			}
 		}
 	}
 	else if (mainBodyReplaced)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -55,7 +55,7 @@ const SMALL_BUTTONS_CONTAINER = "_2DR3u";
 const SMALL_BUTTON = "_32WtB _2i-mO _1LZ7U vy3TL _3iIWE _1Mkpg _1Dtxl _1sVAI sweRn _1BWZU _26exN QVrnU";
 const LOCKED_POPOUT = "_1PDfx";
 
-const SKILL_SELECTOR = `[data-test="skill-tree"] [data-test="skill"], [data-test="intro-lesson"], [data-test="tree-section"] a[href]`;
+const SKILL_SELECTOR = `[data-test="tree-section"] [data-test="skill"], [data-test="intro-lesson"], [data-test="tree-section"] a[href]`;
 const CHECKPOINT_SELECTOR = `[data-test="checkpoint-badge"]`;
 
 const flagYOffsets = {

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -4159,7 +4159,7 @@ async function init()
 
 			lastSkill = await retrieveLastSkill();
 			const pageUrl = window.location.href;
-			if (!pageUrl.includes(`/${lastSkill.urlTitle}/practice`))
+			if (lastSkill != null && !pageUrl.includes(`/${lastSkill.urlTitle}/practice`))
 			{
 				// The lesson we have just entered does not match the lastSkill that was stored.
 				// We must has closed duolingo before it could be cleared properly after the lesson

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.4",
+	"version"			:	"1.3.5",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.4</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.5</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>

--- a/scripts/mergeversion
+++ b/scripts/mergeversion
@@ -7,14 +7,25 @@ if [[ $CURRENTBRANCH == release-* ]] || [[ $CURRENTBRANCH == hotfix-* ]]
 then
 	git checkout master
 	git merge --no-ff $CURRENTBRANCH
-	git push
 
 	git checkout develop
 	git merge --no-ff $CURRENTBRANCH
-	git push
 
-	git push --delete origin $CURRENTBRANCH
-	git branch -d $CURRENTBRANCH
+	echo ""
+	read -p "Push new commits and delete remote and local branches (Y/n)" PUSH
+
+	if [ "$PUSH" != "n" ]
+	then
+		git push
+		git checkout master
+		git push
+		git push --delete origin $CURRENTBRANCH
+		git branch -d $CURRENTBRANCH
+	else
+		echo "Commits not pushed. Note upstream not set."
+		git checkout master
+	fi
+
 else
 	echo "Current branch is not a release or hotfix branch"
 	exit 1

--- a/scripts/newversion
+++ b/scripts/newversion
@@ -50,6 +50,7 @@ sed -i -b "/\"version\"/ s/$OLDVERNUM/$VERNUM/" manifest.json
 sed -i -b "/id=\"version\"/ s/$OLDVERNUM/$VERNUM/" options.html
 
 git add manifest.json
+git add options.html
 git commit -m "Increment version number to $VERNUM"
 
 DATE=$( date +"%F" )


### PR DESCRIPTION
### Changed
- Skill popout is opened and then centred in the view when the tree is loaded
after clicking the practise button. This addresses issue #63.
- Skill selector to only choose skills that are children of a tree section.
This removes a conflict with [DuolingoNextLesson userscript](https://github.com/camiloaa/duolingonextlesson).

### Fixed
- Checkpoint redo buttons added to congratulation message shown when the golden
owl which replaces the last checkpoint is clicked on. This addresses point 7 in #62 
