### PR TITLE
Hotfix 1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.3.8] - 2020-05-02
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.8)
+### Fixed
+- Detection of L0 skills for use in calculating the number of lessons until the
+next checkpoint.
+
 [v1.3.7] - 2020-05-01
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.7)
@@ -768,6 +775,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.7...v1.3.8
 [v1.3.7]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.6...v1.3.7
 [v1.3.6]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.5...v1.3.6
 [v1.3.5]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.4...v1.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changelog
 ### Fixed
 - Detection of L0 skills for use in calculating the number of lessons until the
 next checkpoint.
+- Crowns progress graph showing no progress when crowns info popup is already
+displayed when the features are added. The progress history is now always
+loaded first before adding features.
 
 [v1.3.7] - 2020-05-01
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 [v1.3.8] - 2020-05-02
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.8)
+### Added
+- Maxiumum tree level message to crowns info popup.
+
 ### Fixed
 - Detection of L0 skills for use in calculating the number of lessons until the
 next checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 ### Added
 - Maxiumum tree level message to crowns info popup.
 
+### Changed
+- Renamed 'Crown Level Prediction' option to 'Tree Level Prediction'.
+
 ### Fixed
 - Detection of L0 skills for use in calculating the number of lessons until the
 next checkpoint.

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -3561,7 +3561,8 @@ async function handleDataResponse(responseText)
 
 			resetLanguageFlags();
 
-			retrieveProgressHistory().then(updateProgress);
+			await retrieveProgressHistory();
+			updateProgress();
 
 			usingOldData = false;
 			addFeatures(); // actual processing of the data.
@@ -3583,7 +3584,9 @@ async function handleDataResponse(responseText)
 			// Not a language change and the data is for the current language, just process it.
 			userData = newUserData;
 
-			retrieveProgressHistory().then(updateProgress);
+			await retrieveProgressHistory()
+			updateProgress();
+
 			usingOldData = false;
 			addFeatures();
 		}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -482,7 +482,7 @@ function lessonsToNextCheckpoint()
 	);
 	const level0SkillsBeforeCheckpoint = skillsBeforeCheckpoint.filter(
 		(element) => {
-			return element.querySelectorAll(`img[src$="juicy-crown-unlocked.svg"]`).length != 0;
+			return element.querySelectorAll(`[data-test="level-crown"]`).length == 0;
 		}
 	);
 	return level0SkillsBeforeCheckpoint.reduce(

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2503,6 +2503,14 @@ function displayCrownsBreakdown()
 				crownLevelContainer.appendChild(prediction);
 			}
 		}
+		
+		if (treeLevel === 5)
+		{
+			const maxLevelMessage = document.createElement("p");
+			maxLevelMessage.style.color = "black";
+			maxLevelMessage.textContent = "You have reached the maximum tree level!";
+			crownLevelContainer.appendChild(maxLevelMessage);
+		}
 	}
 	else
 	{

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.7",
+	"version"			:	"1.3.8",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -420,7 +420,7 @@
 				<li>
 					<input class="dummy" type="checkbox" disabled="true" />
 					<input class="option" id="crownsPrediction" type="checkbox" checked="true" />
-					<label for="crownsPrediction">Crown Level Prediction</label>
+					<label for="crownsPrediction">Tree Level Prediction</label>
 				</li>
 			</ul>
 		</li>

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.7</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.8</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
Fix checkpoint progress not showing. This was caused by L0 skills not being selected properly after a duolingo change to the file name for the greyed out crown icon.

Add message to crowns info box when a tree is at L5, to match the message when the user reaches XP Level 25. Renamed the Crown Level Prediction option to Tree Level Prediction. As both mentioned in #62 point 9.

Ensured that the progress history is loaded before any features are added.