### PR TITLE
Hotfix 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v1.3.9] - 2020-05-03
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.9)
+### Fixed
+- Detection for Latin and Gaelic flags when adding the tree level flag borders.
+
 [v1.3.8] - 2020-05-02
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.8)
@@ -784,6 +790,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.8...v1.3.9
 [v1.3.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.7...v1.3.8
 [v1.3.7]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.6...v1.3.7
 [v1.3.6]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.5...v1.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.9)
 ### Fixed
 - Detection for Latin and Gaelic flags when adding the tree level flag borders.
+- Handling of situation where an unpurchased skill is not added to the tree as a
+link to the shop. This happens when the page is loaded onto a tree without bonus
+skills, but is then the language is changed to one where there only one bonus
+skill that has been purchased.
 
 [v1.3.8] - 2020-05-02
 -----------------

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -70,7 +70,10 @@ const flagYOffsets = {
 	772: "hu", 804: "cy", 837: "uk", 869: "kl",
 	901: "cs", 933: "hi", 965: "id", 998: "ha",
 	1030: "nv", 1062: "ar", 1094: "ca", 1126: "th",
-	1159: "gn", 1352: "ar", 1384: "gd",
+	1159: "gn",
+	// 1191: "ambassador", 1223: "duolingo",
+	// 1255: "troubleshooting", 1287: "teachers",
+	1320: "la", 1352: "gd",
 };
 
 let languageCode = "";

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1163,7 +1163,10 @@ function addStrengthBars(strengths)
 
 	for (let i=0; i<skillElements.length; i++)
 	{
+		const isBonusSkill = bonusSkillRow != null && bonusSkillRow.contains(skillElements[i]);
+
 		let elementContents;
+
 		if (
 			skillElements[i].getAttribute("data-test") == "skill" ||
 			skillElements[i].getAttribute("data-test") == "intro-lesson"
@@ -1196,23 +1199,38 @@ function addStrengthBars(strengths)
 
 		// Check if this skill is in the bonus skill section.
 		// In the bonus skill section if the row is sandwiched between two divs with class _32Q0j, that contain an hr.
-		if (bonusSkillRow != null && bonusSkillRow.contains(skillElements[i]))
+		if (isBonusSkill)
 		{
 			// this skill is in the bonus skill section.
-			elementContents.push(strengths[1][bonusElementsCount][0]);
-			elementContents.push(strengths[1][bonusElementsCount][1]);
-			bonusElementsCount ++;
+			if (bonusSkillRow.childElementCount != strengths[1].length)
+			{
+				// One of the bonus skills is missing, this is a duolingo bug that is caused by the page being loaded on a tree that does not have bonus skills,
+				// then switching to a tree that has only one skill purchased.
+				// In this case the unpurchased skill that is normally greyed out and links to the shop to buy it, is not added for some reason.
+				// We then have to work out which skill this is that we are displaying and choose the appropriate strength value.
+				//
+				// Given we know that the missing skill has not been purchased, it is therefore going to be at L0, and therefore have strength 0.
+				// The skill that is displayed will be the other one then.
+				//
+				// Note this all assumes every tree that has bonus skills, has two.
+				
+				const bonusIndex = (strengths[1][0][0] == 0)? 1 : 0;
+				elementContents = elementContents.concat(strengths[1][bonusIndex]);
+				bonusElementsCount = 1;
+			}
+			else
+			{
+				elementContents = elementContents.concat(strengths[1][bonusElementsCount ++]);
+			}
 
-			skills.push(elementContents);
 		}
 		else
 		{
 			// Normal skill
-			elementContents.push(strengths[0][i - bonusElementsCount][0]);
-			elementContents.push(strengths[0][i - bonusElementsCount][1]);
-			
-			skills.push(elementContents);
+			elementContents = elementContents.concat(strengths[0][i - bonusElementsCount]);
 		}
+		
+		skills.push(elementContents);
 	}
 	
 	let numBarsAdded = 0;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.8",
+	"version"			:	"1.3.9",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.8</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.9</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
Fix Latin and Gaelic flag detection when adding flag borders showing the tree level. This fixes #70.

Fix strength bar of bonus skill, where only one bonus skill is added to the tree. This comes from a duolingo bug where if you load the page on a tree without bonus skills, then change to one where only one (of the two) has been purchased, the unpurchased bonus skill is not added to the tree. This is apposed to where it is added as a greyed out skill that links to the shop in the normal case.