### PR TITLE
Hotfix 1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v1.3.10] - 2020-05-05
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.10)
+### Fixed
+- Class name values for the top bar and its navigation buttons.
+
 [v1.3.9] - 2020-05-03
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.9)
@@ -794,6 +800,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.10]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.9...v1.3.10
 [v1.3.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.8...v1.3.9
 [v1.3.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.7...v1.3.8
 [v1.3.7]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.6...v1.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ duolingo plus.
 ### Fixed
 - Class name values for the top bar and its navigation buttons.
 - Class name values for language change, crowns info and streak info popups.
+- Handling of changing between mobile and desktop layout while crown and XP
+popups are displayed.
 
 [v1.3.9] - 2020-05-03
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ Changelog
 [v1.3.10] - 2020-05-05
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.10)
+### Added
+- Support of blue streak flame for mobile XP info adding. This may be from
+duolingo plus.
+
 ### Fixed
 - Class name values for the top bar and its navigation buttons.
+- Class name values for language change, crowns info and streak info popups.
 
 [v1.3.9] - 2020-05-03
 -----------------

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -18,19 +18,19 @@ const MOBILE_TOP_OF_TREE = "_3Y5Xu";
 const SKILL_COLUMN = "QmbDT";
 const TRY_PLUS_BUTTON_SELECTOR = "._2x4yk._1rwed";
 const IN_BETA_LABEL = "_3yV19";
-const CROWN_POPUP_CONTAINER = "NugKJ";
-const CROWN_LOGO_CONTAINER = "_3uwBi";
-const CROWN_DESCRIPTION_CONTAINER = "_27NkX";
-const CROWN_TOTAL_CONTAINER = "_2boWj";
-const DAILY_GOAL_POPUP_CONTAINER = "yRM09";
+const CROWN_POPUP_CONTAINER = "_3hTDu";
+const CROWN_LOGO_CONTAINER = "_3W5VZ";
+const CROWN_DESCRIPTION_CONTAINER = "_13krJ";
+const CROWN_TOTAL_CONTAINER = "_1dP1I";
+const DAILY_GOAL_POPUP_CONTAINER = "_2ewG5"; // parent of streak flame and descript, and the 7 small flames
 const DAILY_GOAL_SIDEBAR_CONATINER = "_2hhXN";
 const SIDEBAR = "_3Nl60";
 const WHITE_SIDEBAR_BOX_CONTAINER = "_2iVqi";
-const POPUP_ICON = "_3gtu3 _1-Eux iDKFi";
-const GOLD_CROWN = "WZkQ9";
-const GREY_CROWN = "_3FM63";
-const COLOURED_FLAME = "_2ctH6";
-const GREY_FLAME = "_27oya";
+const POPUP_ICON = "z0qDl _1rcDl _3xl-g";
+const GOLD_CROWN = "_3JJjF";
+const LIT_FLAME = "_2ES5X";
+const BLUE_FLAME = "_144wX";
+const GREY_FLAME = "_9Fm3O";
 const ACTIVE_TAB = "_2lkuX";
 const TOP_BAR = "_1frzL";
 const NAVIGATION_BUTTON = "_1hmv9";
@@ -49,7 +49,7 @@ const SKILL_NAME_SELECTOR = "._2CXf4";
 const CHECKPOINT_CONTAINER_SELECTOR = "._3Lrsa";
 const CHECKPOINT_POPOUT_SELECTOR = "._15Wh7._6gtoB";
 const CHECKPOINT_BLURB_SELECTOR = "._3-EWe";
-const LANGUAGES_LIST_SELECTOR = "._2-Lx6";
+const LANGUAGES_LIST_SELECTOR = ".eanIR";
 const SMALL_BUTTONS_CONTAINER = "_2DR3u";
 const SMALL_BUTTON = "_32WtB _2i-mO _1LZ7U vy3TL _3iIWE _1Mkpg _1Dtxl _1sVAI sweRn _1BWZU _26exN QVrnU";
 const LOCKED_POPOUT = "_1PDfx";
@@ -4044,7 +4044,7 @@ let childListMutationHandle = function(mutationsList, observer)
 			return false;
 		}
 
-		if (popupIcon.getElementsByClassName(GOLD_CROWN).length + popupIcon.getElementsByClassName(GREY_CROWN).length != 0) // WZkQ9 for gold crown logo, _3FM63 for grey when at 0 crowns.
+		if (popupIcon.getElementsByClassName(GOLD_CROWN).length != 0) // Grey crown doesn't seem to have its own class now, it has the same as gold.
 		{
 			// Crowns has had the change.
 			if (options.crownsInfo && popupIcon.lastChild.nodeName == 'DIV')
@@ -4058,7 +4058,12 @@ let childListMutationHandle = function(mutationsList, observer)
 			}
 		}
 
-		if (popupIcon.getElementsByClassName(COLOURED_FLAME).length +  popupIcon.getElementsByClassName(GREY_FLAME).length != 0) // _2ctH6 for coloured flame logo, _27oya for grey when not met day's XP goal.
+		if (
+			popupIcon.getElementsByClassName(LIT_FLAME).length
+			+ popupIcon.getElementsByClassName(GREY_FLAME).length
+			+ popupIcon.getElementsByClassName(BLUE_FLAME).length
+			!= 0
+		) // Lit flame for streak extended today, grey for not, blue possibly for frozen with duolingo plus?
 		{
 			// Streak/XP has had the change.
 			if (options.XPInfo && popupIcon.lastChild.nodeName == 'DIV')

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2600,7 +2600,12 @@ function displayXPBreakdown()
 	if (removeCurrentBox)
 		currentXPBox.remove();
 
-	if (document.getElementById("XPBox") == null)
+	if (
+		(!inMobileLayout && document.querySelectorAll(`.${DAILY_GOAL_SIDEBAR_CONATINER} #XPBox`).length === 0)
+		||
+		(inMobileLayout && document.querySelectorAll(`.${DAILY_GOAL_POPUP_CONTAINER} #XPBox`).length === 0)
+	)
+
 	{
 		// We haven't made the XP Box yet
 
@@ -4027,11 +4032,13 @@ let childListMutationHandle = function(mutationsList, observer)
 				document.getElementById("fullStrengthMessageContainer").style.width = desktopWidth;
 			}
 			
-
-			// Try and add the XP box again as the sidebar has come back
-			if (options.XPInfo) displayXPBreakdown();
-			if (options.languagesInfo) displayLanguagesInfo(getLanguagesInfo());
 		}
+		// Try and add the Crowns and XP info in case the popups are there.
+		if (options.XPInfo) displayXPBreakdown();
+		if (options.crownsInfo) displayCrownsBreakdown();
+
+		// Try to add the languages info incase the sidebar has been added back.
+		if (options.languagesInfo) displayLanguagesInfo(getLanguagesInfo());
 	}
 
 	if (popupChanged)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -15,7 +15,6 @@ const BONUS_SKILL_DIVIDER_SELECTOR = "._23P6X";
 const TOP_OF_TREE_WITH_IN_BETA = "_1uUHs _3tYmC";
 const TOP_OF_TREE = "_3GFex";
 const MOBILE_TOP_OF_TREE = "_3Y5Xu";
-const SKILL_ROW = "_2GJb6";
 const SKILL_COLUMN = "QmbDT";
 const TRY_PLUS_BUTTON_SELECTOR = "._2x4yk._1rwed";
 const IN_BETA_LABEL = "_3yV19";
@@ -33,8 +32,8 @@ const GREY_CROWN = "_3FM63";
 const COLOURED_FLAME = "_2ctH6";
 const GREY_FLAME = "_27oya";
 const ACTIVE_TAB = "_2lkuX";
-const TOP_BAR = "_3F_8q";
-const NAVIGATION_BUTTON = "_3MT82";
+const TOP_BAR = "_1frzL";
+const NAVIGATION_BUTTON = "_1hmv9";
 const QUESTION_CONTAINER = "_2NEKS";
 const LOGIN_PAGE = "_11AR-";
 const LESSON = "_7TCY- _160QG";
@@ -4388,6 +4387,7 @@ async function init()
 				let storiesNav;
 				// let discussionNav;
 				let shopNav;
+				// languageLogo declared globally for use outside init;
 				let crownNav;
 				let streakNav;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.9",
+	"version"			:	"1.3.10",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.9</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.10</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
Update class names after a duolingo update. As reported on the forums and in #73.
Fix handling of XP and crown popups changing between mobile and desktop layouts.