### PR TITLE
Hotfix 1.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v1.3.11] - 2020-05-18
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.11)
+### Fixed
+- Username extraction from page.
+
 [v1.3.10] - 2020-05-05
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.10)
@@ -807,6 +813,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.11]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.10...v1.3.11
 [v1.3.10]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.9...v1.3.10
 [v1.3.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.8...v1.3.9
 [v1.3.8]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.7...v1.3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 [v1.3.11] - 2020-05-18
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.11)
+### Added
+- Option to toggle the hiding of translation sentences that contain new words.
+
 ### Fixed
 - Username extraction from page.
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -4378,8 +4378,8 @@ async function init()
 				// there is a topBarDiv so we can continue to process the page to workout what to do
 
 				// set username via the href of a link to the profile
-				let profileTabHrefParts = document.querySelector(`[data-test="profile-tab"]`).href.split("/");
-				username = profileTabHrefParts[profileTabHrefParts.length - 1];
+				let profileLinkHrefParts = document.querySelector(`[href^="/profile/"]`).href.split("/");
+				username = profileLinkHrefParts[profileLinkHrefParts.length - 1];
 
 				// topBar Div is the direct container holding the navigation butons, has class _3F_8q
 				// old method topBarDiv = dataReactRoot.childNodes[2].childNodes[1].childNodes[2].childNodes[0];

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -147,6 +147,7 @@ function retrieveOptions()
 					"showTranslationText":						true,
 						"revealHotkey":								true,
 							"revealHotkeyCode":							"Ctrl+Alt+H",
+						"showNewWords":								true,
 					"showToggleHidingTextButton":				true,
 					"showLeagues":								true,
 					"wordsButton":								true,
@@ -3678,8 +3679,24 @@ function hideTranslationText(reveal = false, setupObserver = true)
 			const hintSentence = challengeTranslatePrompt.querySelector('[data-test="hint-sentence"]');
 			
 
-			if (hintSentence.querySelectorAll(NEW_WORD_SELECTOR).length != 0)
-				return false; // There is a new word, so we don't want to be hiding this sentence.
+			if (options.showNewWords && hintSentence.querySelectorAll(NEW_WORD_SELECTOR).length != 0)
+			{
+				// There is a new word, so we don't want to be hiding this sentence.
+				hintSentence.style.filter = "none";
+				hintSentence.title = "";
+				const enableDisableButton = questionContainer.querySelector(`.hideTextEnableDisable`);
+				if (enableDisableButton !== null)
+				{
+					// Remove the enable disable button
+					const headerContainer = questionContainer.querySelector(`.hideTextEnableDisable`).parentNode;
+					const header = headerContainer.firstChild;
+					header.removeAttribute("style");
+					headerContainer.parentNode.insertBefore(header, headerContainer); // Move the header back to where it should be;
+					headerContainer.remove();
+				}
+
+				return false;
+			}
 
 			if (options.showTranslationText == false && reveal == false)
 			{

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.10",
+	"version"			:	"1.3.11",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -480,6 +480,11 @@
 						</li>
 					</ul>
 				</li>
+				<li>
+					<input class="dummy" type="checkbox" disabled="true" />
+					<input class="option" id="showNewWords" type="checkbox" checked="true" />
+					<label for="showNewWords">Show Sentences with New (Yellow) Words<label>
+				</li>
 			</ul>
 		</li>
 		<li>

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.10</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.11</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
Fix username extraction from the user's profile link.

Add option to toggle hiding of translation sentences that contain a new word.