### PR TITLE
Hotfix 1.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ Changelog
 ### Changed
 - Content script and page action page matches to include the preview subdomain.
 - Increased scale on crown image behind crown count total to match old sizing.
-The image is now big enough to cover the widest maxiumum three digit crown
+The image is now big enough to cover the widest maximum three digit crown
 total e.g. 999/999.
 
 ### Added
 - Detection of no element with a link to the user's profile, and thus nowhere
 to the username from. An error message is send to the console in this case.
+- Tooltip giving lesson rate and number of lessons left to the words 
+`current rate` in the prediction text for tree level and checkpoint
+predictions.
 
 [v1.3.11] - 2020-05-18
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.12)
 ### Changed
 - Content script and page action page matches to include the preview subdomain.
+- Increased scale on crown image behind crown count total to match old sizing.
+The image is now big enough to cover the widest maxiumum three digit crown
+total e.g. 999/999.
 
 ### Added
 - Detection of no element with a link to the user's profile, and thus nowhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v1.3.12] - 2020-06-09
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.12)
+### Changed
+- Content script and page action page matches to include the preview subdomain.
+
 [v1.3.11] - 2020-05-18
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.11)
@@ -816,6 +822,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.12]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.11...v1.3.12
 [v1.3.11]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.10...v1.3.11
 [v1.3.10]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.9...v1.3.10
 [v1.3.9]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.8...v1.3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changelog
 ### Changed
 - Content script and page action page matches to include the preview subdomain.
 
+### Added
+- Detection of no element with a link to the user's profile, and thus nowhere
+to the username from. An error message is send to the console in this case.
+
 [v1.3.11] - 2020-05-18
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.11)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2178,9 +2178,8 @@ function displayCrownsBreakdown()
 		`;
 	}
 	let crownLogoContainer = document.getElementsByClassName(CROWN_LOGO_CONTAINER)[inMobileLayout? 1 : 0];
-	const emptyCrown = crownLogoContainer.querySelector(`img[src$="juicy-crown-empty.svg"]`);
-	if (emptyCrown != null)
-		emptyCrown.style["transform"] = "scale(1.3)";
+	const crownCountImg = crownLogoContainer.querySelector(`:scope > img`);
+	crownCountImg.style["transform"] = "scale(1.3)";
 
 	let crownDescriptionContainer = document.getElementsByClassName(CROWN_DESCRIPTION_CONTAINER)[inMobileLayout ? 1 : 0];
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -4395,8 +4395,19 @@ async function init()
 				// there is a topBarDiv so we can continue to process the page to workout what to do
 
 				// set username via the href of a link to the profile
-				let profileLinkHrefParts = document.querySelector(`[href^="/profile/"]`).href.split("/");
-				username = profileLinkHrefParts[profileLinkHrefParts.length - 1];
+				const profileLinkElement = document.querySelector(`[href^="/profile/"]`);
+				if (profileLinkElement === null)
+				{
+					// no element with the username in has been found
+					console.error("Username could not be pulled from the page:\nNo link to the user's profile found");
+					return false;
+				}
+				else
+				{
+					const profileLinkHrefParts = document.querySelector(`[href^="/profile/"]`).href.split("/");
+					username = profileLinkHrefParts[profileLinkHrefParts.length - 1];
+				}
+
 
 				// topBar Div is the direct container holding the navigation butons, has class _3F_8q
 				// old method topBarDiv = dataReactRoot.childNodes[2].childNodes[1].childNodes[2].childNodes[0];

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.11",
+	"version"			:	"1.3.12",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
 	},
 
 	"page_action"		:	{
-		"show_matches"	:	["https://www.duolingo.com/*"],
+		"show_matches"	:	["https://www.duolingo.com/*", "https://preview.duolingo.com/*"],
 		"default_icon"	:	{
 			"16"		: 	"icons/icon_16.png",
 			"32"		:	"icons/icon_32.png",
@@ -31,7 +31,7 @@
 	
 	"content_scripts"	:	[
 		{
-			"matches"	:	["https://www.duolingo.com/*"],
+			"matches"	:	["https://www.duolingo.com/*", "https://preview.duolingo.com/*"],
 			"js"		: 	["duoStrength.js"]
 		}
 	],

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.11</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.12</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
### Changed
- Content script and page action page matches to include the preview subdomain.
- Increased scale on crown image behind crown count total to match old sizing. The image is now big enough to cover the widest maximum three digit crown total e.g. 999/999.

### Added
- Detection of no element with a link to the user's profile, and thus nowhere to the username from. An error message is send to the console in this case.
- Tooltip giving lesson rate and number of lessons left to the words  `current rate` in the prediction text for tree level and checkpoint predictions.