### PR TITLE
Hotfix 1.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 ### Fixed
 - Skill names to use to short name instead of title. This makes the name of the
 skills shown in lists consistent with the name of the skill in the tree.
+- Detection of cracked skills.
 
 [v1.3.23] - 2020-06-29
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Changelog
 skills shown in lists consistent with the name of the skill in the tree.
 - Detection of cracked skills.
 
+### Changed
+- Updated README introduction to match the User Guide's introduction on the
+wiki.
+
 [v1.3.23] - 2020-06-29
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 - Skill names to use to short name instead of title. This makes the name of the
 skills shown in lists consistent with the name of the skill in the tree.
 - Detection of cracked skills.
+- Loading of extension after logging in.
 
 ### Changed
 - Updated README introduction to match the User Guide's introduction on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.3.24] - 2020-06-30
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.24)
+### Fixed
+- Skill names to use to short name instead of title. This makes the name of the
+skills shown in lists consistent with the name of the skill in the tree.
+
 [v1.3.23] - 2020-06-29
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.23)
@@ -923,6 +930,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.24]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.23...v1.3.24
 [v1.3.23]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.22...v1.3.23
 [v1.3.22]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.21...v1.3.22
 [v1.3.21]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.20...v1.3.21

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Duo Strength
-Duo Strength is a browser extension for the [Duolingo language learning platform](https://www.duolingo.com/) that adds a visual indication hidden and removed details into your language tree and Duolingo interface itself. Inspired by the user profile pages on the [duome unofficial streak hall of fame website](https://duome.eu/), Duo Strength gives a way to view this information without needed to leave Duolingo or have two pages open.
+Duo Strength is a browser extension to improve the user interface [Duolingo language learning platform](https://www.duolingo.com/). At its core it adds a visual indication of hidden and removed details into your language tree and Duolingo interface itself, in particular the strength of each individual skill. Inspired by the user profile pages on the [duome unofficial streak hall of fame website](https://duome.eu/), Duo Strength gives a way to view much of this information and more without needed to leave Duolingo or have two pages open.
 
 ## Main features:
 - Strength bars added under each skill in the tree

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2129,7 +2129,7 @@ function getCrackedSkills()
 		(crackedSkill) => {
 			const skillIcon = crackedSkill.parentNode.parentNode;
 			const skillContainer = skillIcon.parentNode.parentNode.parentNode;
-			const skillName = skillContainer.lastChild.lastChild.textContent;
+			const skillName = skillContainer.lastChild.textContent;
 
 			return skillName;
 		}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -102,6 +102,7 @@ let mainBodyContainer;
 let topBarDiv;
 
 let onMainPage;
+let onLoginPage;
 let inMobileLayout;
 
 let lastSkill;
@@ -3915,8 +3916,14 @@ function childListMutationHandle(mutationsList, observer)
 	{
 		if (
 			mutation.target === rootElem
-			&& mutation.addedNodes.length === 1
-			&& mutation.target.childElementCount === 1
+			&&
+			(
+				(
+					mutation.addedNodes.length === 1
+					&& mutation.target.childElementCount === 1
+				)
+				|| onLoginPage
+			)
 		)
 		{
 			rootChildReplaced = true;
@@ -4491,11 +4498,14 @@ async function init()
 	{
 		// On login page so cannot continue to run rest of init process.
 		onMainPage = false;
+		onLoginPage = true;
 		return false;
 	}
 	else
 	{
 		// should be logged in
+		onLoginPage = false;
+
 		// now test to see if we are in a lesson or not
 
 		if (rootChild.firstChild.className == LESSON)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1459,7 +1459,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 	*/
 	function sortSkillsAlphabetical(a, b)
 	{
-		return (a.title < b.title) ? -1 : 1;
+		return (a.short < b.short) ? -1 : 1;
 	}
 
 	function shuffle(array)
@@ -1637,7 +1637,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 							     options.practiceType == "1" ||
 							     (options.practiceType == "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
 							    ) ? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		} else
 		{
 			// index has past normal skills so doing bonus skills now.
@@ -1645,7 +1645,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level == 1)? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		}
 
 		strengthenBox.appendChild(skillLink);
@@ -1679,7 +1679,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[1][needsStrengthening[1].length -1];
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level == 1)? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		} else
 		{
 			// last skill to be displayed is a normal skill
@@ -1690,7 +1690,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 								 options.practiceType == "1" ||
 								 (options.practiceType == "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
 							    )? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		}
 		
 		strengthenBox.appendChild(skillLink);
@@ -1711,7 +1711,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 							     options.practiceType == "1" ||
 								 (options.practiceType == "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
 							    )? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		} else
 		{
 			// index has past normal skills so doing bonus skills now.
@@ -1719,7 +1719,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level == 1)? "/practice":""}`;
-			skillLink.textContent = skill.title;
+			skillLink.textContent = skill.short;
 		}
 		strengthenBox.appendChild(skillLink);
 		strengthenBox.appendChild(document.createTextNode(", "));
@@ -3107,7 +3107,7 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 
 		let link = document.createElement("a");
 		link.href = "/skill/" + languageCode + "/" + randomSuggestion.url_title + ((treeLevel == 5) ? "/practice/" : "/");
-		link.textContent = randomSuggestion.title;
+		link.textContent = randomSuggestion.short;
 		link.style.color = 'blue';
 		link.addEventListener('focus',
 			function(event)
@@ -3178,7 +3178,7 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 			{
 				// The next skil is unlocked so lets suggest it.
 				link.href = `/skill/${languageCode}/${nextSkill.url_title}/`;
-				link.textContent = nextSkill.title;
+				link.textContent = nextSkill.short;
 
 				suggestionMessage.textContent += "The next skill to learn is: ";
 			}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -41,7 +41,7 @@ const LESSON_MAIN_SECTION = "_14_MG";
 const LESSON_BOTTOM_SECTION = "_1obm2";
 const QUESTION_UNCHECKED = "zEs4P";
 const QUESTION_CHECKED = "_1NmT0";
-const CRACKED_SKILL_OVERLAY_SELECTOR = "._7WUMp";
+const CRACKED_SKILL_OVERLAY_SELECTOR = "._1x_0f";
 const NEW_WORD_SELECTOR = "._2o9QZ";
 const LEAGUE_TABLE = "_1NIUo";
 const SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR = ".vwODZ";
@@ -2127,7 +2127,7 @@ function getCrackedSkills()
 	const crackedSkillElements = Array.from(document.querySelectorAll(CRACKED_SKILL_OVERLAY_SELECTOR));
 	const crackedSkillNames = crackedSkillElements.map(
 		(crackedSkill) => {
-			const skillIcon = crackedSkill.parentNode;
+			const skillIcon = crackedSkill.parentNode.parentNode;
 			const skillContainer = skillIcon.parentNode.parentNode.parentNode;
 			const skillName = skillContainer.lastChild.lastChild.textContent;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.23",
+	"version"			:	"1.3.24",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.23</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.24</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
### Fixed
- Skill names to use to short name instead of title. This makes the name of the skills shown in lists consistent with the name of the skill in the tree.
- Detection of cracked skills.
- Loading of extension after logging in.

### Changed
- Updated README introduction to match the User Guide's introduction on the wiki.