### PR TITLE
Hotfix 1.3.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog
 ------------
 -
 
+[v1.3.38] - 2020-10-28
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.38)
+### Fixed
+- The tree level calculation now ignores grammar skills. This had caused the
+tree level to be stuck at level 2, the maximum level that grammar skills can
+get to.
+
 [v1.3.37] - 2020-10-26
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.37)
@@ -1046,6 +1054,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.38]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.37...v1.3.38
 [v1.3.37]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.36...v1.3.37
 [v1.3.36]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.35...v1.3.36
 [v1.3.35]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.34...v1.3.35

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -450,13 +450,11 @@ function hasMetGoal()
 
 function currentProgress()
 {
-	let skills = userData.language_data[languageCode].skills;
+	const skills = userData.language_data[languageCode].skills;
 	let treeLevel = currentTreeLevel();
 	let lessonsToNextTreeLevel = 0;
 	for (let skill of skills)
 	{
-		//if (skill.locked) continue;
-		
 		if (skill.skill_progress.level == treeLevel)
 		{
 			lessonsToNextTreeLevel += skill.num_sessions_for_level - skill.level_sessions_finished;
@@ -606,9 +604,9 @@ function progressMadeBetweenPoints(startIndex, endIndex)
 
 function currentTreeLevel()
 {
-	let skills = userData.language_data[languageCode].skills;
+	const skills = userData.language_data[languageCode].skills.filter(skill => skill.category !== "grammar");
 
-	let skillsByCrowns = [[],[],[],[],[],[]];
+	const skillsByCrowns = [[],[],[],[],[],[]];
 
 	for (let skill of skills)
 	{
@@ -704,17 +702,7 @@ function daysToNextTreeLevel()
 
 function daysToNextTreeLevelByCalendar()
 {
-	let skills = userData.language_data[languageCode].skills;
-	let treeLevel = currentTreeLevel();
-	let lessonsToNextTreeLevel = 0;
-
-	for (let skill of skills)
-	{
-		if (skill.skill_progress.level == treeLevel)
-		{
-			lessonsToNextTreeLevel += skill.num_sessions_for_level - skill.level_sessions_finished;
-		}
-	}
+	const lessonsToNextTreeLevel = currentProgress();
 
 	const calendar = currentLanguageHistory();
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.37",
+	"version"			:	"1.3.38",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.37</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.38</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
### Fixed
- The tree level calculation now ignores grammar skills. This had caused the
tree level to be stuck at level 2, the maximum level that grammar skills can
get to.