### PR TITLE
Hotfix 1.3.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v1.3.41] - 2020-12-09
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.41)
+### Fixed
+- Progress history to only store 7 most recent improvements. This stops the
+storage from filling up with old data that will not be used.
+
 [v1.3.40] - 2020-11-23
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.40)
@@ -1069,6 +1076,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.41]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.40...v1.3.41
 [v1.3.40]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.39...v1.3.40
 [v1.3.39]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.38...v1.3.39
 [v1.3.38]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.37...v1.3.38

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -277,9 +277,31 @@ function updateProgress()
 		else
 		{
 			// No change since the last entry so we will not save it.
-			return false;
 		}
 	}
+
+	// Trim down progress to only keep 7 most recent improvements
+	let numImprovements = 0;
+	let index = progress.length - 1;
+	let treeLevel = progress[index][1];
+	let lastProgress = progress[index--][2];
+	while (numImprovements < 7 && index >= 0)
+	{
+		if (progress[index][2] > lastProgress)
+		{
+			++numImprovements;
+		}
+		else if (progress[index][1] < treeLevel)
+		{
+			++numImprovements;
+		}
+
+		lastProgress = progress[index][2];
+		treeLevel = progress[index][1];
+		--index;
+	}
+
+	progress = progress.slice(++index);
 
 	storeProgressHistory();
 	return true;
@@ -513,7 +535,7 @@ function lessonsToNextCheckpoint()
 	, 0);
 }
 
-function progressEnds(numPointsToUse)
+function progressEnds()
 {
 	let endIndex = progress.length - 1;
 	let lastDate = progress[endIndex][0];
@@ -524,12 +546,10 @@ function progressEnds(numPointsToUse)
 		lastDate = progress[--endIndex][0];
 	}
 
-	const startIndex = Math.max(endIndex - numPointsToUse + 1, 0);
-	
-	const numDays = (lastDate  - progress[startIndex][0]) / (1000*60*60*24) + 1; // inclusive of start and end
+	const numDays = (lastDate  - progress[0][0]) / (1000*60*60*24) + 1; // inclusive of start and end
 	
 	return {
-		startIndex: startIndex,
+		startIndex: 0,
 		endIndex: endIndex,
 		numDays: numDays
 	};
@@ -679,8 +699,7 @@ function daysToNextXPLevel(history, xpLeft)
 
 function daysToNextTreeLevel()
 {
-	const numPointsToUse = 7;
-	const {startIndex, endIndex, numDays} = progressEnds(numPointsToUse);
+	const {startIndex, endIndex, numDays} = progressEnds();
 	
 	const progressRate = progressMadeBetweenPoints(startIndex, endIndex) / numDays // in lessons per day
 
@@ -761,8 +780,7 @@ function daysToNextTreeLevelByCalendar()
 
 function daysToNextCheckpoint()
 {
-	const numPointsToUse = 7;
-	const {startIndex, endIndex, numDays} = progressEnds(numPointsToUse);
+	const {startIndex, endIndex, numDays} = progressEnds();
 
 	const progressRate = progressMadeBetweenPoints(startIndex, endIndex) / numDays // in lessons per day
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.40",
+	"version"			:	"1.3.41",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.40</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.41</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
### Fixed
- Progress history to only store 7 most recent improvements. This stops the storage from filling up with old data that will not be used. (See issue #117)
