### PR TITLE
Hotfix 1.3.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Changelog
 ------------
 -
 
+[v1.3.42] - 2020-12-10
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.42)
+### Changed
+- Any user+tree combinations for which the most recent progress history entry
+is more than 3 months ago is removed to save space as the tree is most likely
+inactive.
+- Format of the key under which the progress history of a user tree is saved to
+use the user's ID rather than the username. This is to stop new entries being
+created if the user changes username. Any existing entries under the old format
+will be transferred to the new format then removed if the user uses that tree.
+
+### Depreciated
+- Old username based key format for saving the progress history. After 3 months
+the transferring of old format data will be stopped. Tthis data will have
+either been transferred or deleted for being old.
+
 [v1.3.41] - 2020-12-09
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.41)
@@ -1076,6 +1093,7 @@ strengthening, above the first skill in the tree.
 from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v1.3.42]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.41...v1.3.42
 [v1.3.41]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.40...v1.3.41
 [v1.3.40]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.39...v1.3.40
 [v1.3.39]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.38...v1.3.39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog
 [v1.3.42] - 2020-12-10
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v1.3.42)
+### Fixed
+- Styling of messages at the top of the tree to make more room for the new try
+plus icon.
+
 ### Changed
 - Any user+tree combinations for which the most recent progress history entry
 is more than 3 months ago is removed to save space as the tree is most likely
@@ -19,7 +23,7 @@ will be transferred to the new format then removed if the user uses that tree.
 
 ### Depreciated
 - Old username based key format for saving the progress history. After 3 months
-the transferring of old format data will be stopped. Tthis data will have
+the transferring of old format data will be stopped. This data will have
 either been transferred or deleted for being old.
 
 [v1.3.41] - 2020-12-09

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1657,15 +1657,12 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 		{
 			// If there is the IN BETA label, make it relative, not aboslute.
 			topOfTree.getElementsByClassName(IN_BETA_LABEL)[0].style.position = 'relative';
-			if (inMobileLayout)
-				strengthenBox.style.marginTop = "1.5em";
-			else
-				strengthenBox.style.marginTop = "0.5em";
+			strengthenBox.style.marginTop = "0.5em";
 		}
-		else if (document.querySelector(TRY_PLUS_BUTTON_SELECTOR) != null)
+
+		if (document.querySelector(TRY_PLUS_BUTTON_SELECTOR) !== null)
 		{
-			// Not being pushed down by the IN BETA label,
-			// and there is a TRY PLUS button on the right which we have to make room for.
+			// There is a TRY PLUS button on the right which we have to make room for.
 			const boxRightEdge = topOfTree.getBoundingClientRect().right;
 			const buttonLeftEdge = document.querySelector(TRY_PLUS_BUTTON_SELECTOR).getBoundingClientRect().left;
 			const offset = boxRightEdge - buttonLeftEdge;
@@ -3338,19 +3335,23 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 		{
 			// If there is the IN BETA label, make it relative, not absolute.
 			topOfTree.getElementsByClassName(IN_BETA_LABEL)[0].style.position = 'relative';
-			if (inMobileLayout)
-				container.style.marginTop = "1.5em";
-			else
-				container.style.marginTop = "0.5em";
+			container.style.marginTop = "0.5em";
 		}
-		else if (document.querySelector(TRY_PLUS_BUTTON_SELECTOR) != null)
+
+		if (document.querySelector(TRY_PLUS_BUTTON_SELECTOR) != null)
 		{
-			// Not being pushed down by the IN BETA label,
-			// and there is a TRY PLUS button on the right which we have to make room for.
+			// There is a TRY PLUS button on the right which we have to make room for.
 			const boxRightEdge = topOfTree.getBoundingClientRect().right;
 			const buttonLeftEdge = document.querySelector(TRY_PLUS_BUTTON_SELECTOR).getBoundingClientRect().left;
 			const offset = boxRightEdge - buttonLeftEdge;
-			container.style.width = `calc(100% - ${offset}px - 0.5em)`;
+			if (inMobileLayout)
+			{
+				container.style.width = `calc(100% - ${offset}px - 1.5em)`;
+			}
+			else
+			{
+				container.style.width = `calc(100% - ${offset}px - 0.5em)`;
+			}
 		}
 		const skills = userData.language_data[languageCode].skills;
 		const treeLevel = currentTreeLevel();
@@ -4400,14 +4401,14 @@ function childListMutationHandle(mutationsList, observer)
 			const buttonLeftEdge = document.querySelector(TRY_PLUS_BUTTON_SELECTOR).getBoundingClientRect().left;
 			const offset = boxRightEdge - buttonLeftEdge;
 			desktopWidth = `calc(100% - ${offset}px - 0.5em)`;
+			mobileWidth = `calc(100% - ${offset}px - 1.5em)`;
 		}
 
 		if (document.getElementsByClassName(IN_BETA_LABEL).length != 0)
 		{
 			// There is an IN BETA label
-			mobileMargin = "1.5em 1em 0.5em 1em";
-			desktopMargin = "0.5em 1em 2em 1em";
-			desktopWidth = "auto";
+			mobileMargin = "0.5em 1em 0.5em 1em";
+			desktopMargin = "0.5em 0 2em 0";
 		}
 
 		if (document.querySelector(BOTTOM_NAV_SELECTOR) !== null)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"1.3.41",
+	"version"			:	"1.3.42",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -227,7 +227,7 @@
 	</style>
 </head>
 <body>
-	<h1>Duo Strength Options <span id="version">v1.3.41</span></h1>
+	<h1>Duo Strength Options <span id="version">v1.3.42</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul>
 		<li>


### PR DESCRIPTION
### Fixed
- Styling of messages at the top of the tree to make more room for the new try plus icon.

### Changed
- Any user+tree combinations for which the most recent progress history entry is more than 3 months ago is removed to save space as the tree is most likely inactive.
- Format of the key under which the progress history of a user tree is saved to use the user's ID rather than the username. This is to stop new entries being created if the user changes username. Any existing entries under the old format will be transferred to the new format then removed if the user uses that tree.

### Depreciated
- Old username based key format for saving the progress history. After 3 months the transferring of old format data will be stopped. This data will have either been transferred or deleted for being old.

See issue #117 for more details on progress history changes.