### PR TITLE
Mastered skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ full width.
   - Option to enable and disable focus mode.
   - Button to bottom of the page to toggle the focus mode.
   - Option to enable and disabled the focus mode button.
-- Button next to suggestion link, to open that skill's popout bubble.
+- Button next to links in lists at the top of the tree, to open that skill's
+popout bubble.
+ - Options to toggle these buttons for the different lists.
 - Option to make sidebar fixed when scrolling down the page, and hidden content
 scrollable.
 - Automatic clicking of new words in lessons to reveal their translations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ scrollable.
 - Option to only show skills in the tree that need to be addressed. This means
 cracked skills, skills that need strengthening, or a suggested skill to practise
 next.
+- Button to skill popouts to mark skills as 'mastered', which forces their
+strength to be 100%. This can be used to ignore skills that are stuck needing
+strengthening.
+  - Option to toggle the button in skill popouts.
+  - Option to toggle the forcing of the skills marked as mastered to 100%.
 
 ### Changed
 - Grammar skills are now separated in the crowns info breakdown. There are

--- a/options.html
+++ b/options.html
@@ -288,6 +288,11 @@
 					<input class="option" id="showBonusSkillsInNeedsStrengtheningList" type="checkbox" checked />
 					<label for="showBonusSkillsInNeedsStrengtheningList">Show Bonus Skills in List</label>
 				</li>
+				<li>
+					<input class="dummy" type="checkbox" disabled />
+					<input class="option" id="needsStrengtheningPopoutButton" type="checkbox" checked />
+					<label for="needsStrengtheningPopoutButton">Skill Popout Button</label>
+				</li>
 			</ul>
 		</li>
 		<li>
@@ -313,6 +318,11 @@
 					<input class="dummy" type="checkbox" disabled />
 					<input class="option" id="showBonusSkillsInCrackedSkillsList" type="checkbox" checked />
 					<label for="showBonusSkillsInCrackedSkillsList">Show Bonus Skills in List</label>
+				</li>
+				<li>
+					<input class="dummy" type="checkbox" disabled />
+					<input class="option" id="crackedPopoutButton" type="checkbox" checked />
+					<label for="crackedPopoutButton">Skill Popout Button</label>
 				</li>
 			</ul>
 		</li>

--- a/options.html
+++ b/options.html
@@ -380,6 +380,17 @@
 			<label for="grammarSkillsTestButton">Test Out Button for Grammar Skills</label>
 		</li>
 		<li>
+			<input class="option" id="ignoreMasteredSkills" type="checkbox" checked />
+			<label for="ignoreMasteredSkills">Force Skills Marked as Mastered to 100% Strength</label>
+			<ul>
+				<li>
+					<input class="dummy" type="checkbox" disabled />
+					<input class="option" id="masteredButton" type="checkbox" checked />
+					<label for="masteredSkillButton">Mark Skill as Mastered Button in Skill Popouts</label>
+				</li>
+			</ul>
+		</li>
+		<li>
 			<input class="option" id="checkpointButtons" type="checkbox" checked />
 			<label for="checkpointButtons">Retry &amp; Test Out Buttons on Completed Checkpoints</label>
 		</li>


### PR DESCRIPTION
### Added
- Button to skill popouts to mark skills as 'mastered', which forces their strength to be 100%. This can be used to ignore skills that are stuck needing strengthening.
  - Option to toggle the button in skill popouts.
  - Option to toggle the forcing of the skills marked as mastered to 100%.

To make these buttons easier to get to:
### Changed
- Button next to links in ALL lists at the top of the tree, to open that skill's popout bubble.
 - Options to toggle these buttons for the different lists.
