### PR TITLE
Focus Priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ as 100% strength.
   - Option to enable or disable this.
 - A second set of buttons at the bottom of tips pages.
   - Option to enable or disable this.
+- Sub option to the Focus First Skills Option to set the priority order for which
+of the lists at the top of the tree is initially focused.
 
 ### Changed
 - Grammar skills are now separated in the crowns info breakdown. There are

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -144,6 +144,7 @@ function retrieveOptions()
 						"suggestionPopoutButton":					true,
 					"showOnlyNeededSkills":						false,
 					"focusFirstSkill":							true,
+						"focusPriorities":							"0",
 					"practiseButton":							true,
 					"practiceType":								"0",
 						"lessonThreshold":							"4",
@@ -2131,12 +2132,21 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 	{
 		cracked ? removeCrackedPopoutButton() : removeNeedsStrengtheningPopoutButton();
 	}
+}
 
-	if (options.focusFirstSkill)
-	{
-		firstSkillLink.focus();
-	}
-
+function focusFirstSkill()
+{
+	Array.from(options.focusPriorities).map(
+		(abrv) =>
+		{
+			if (abrv === "n") return "strengthenBox";
+			if (abrv === "c") return "crackedBox";
+			if (abrv === "s") return "skillSuggestionMessageContainer";
+		}
+	).map(id => document.querySelector(`#${id} a`))
+	.filter(elem => elem !== null)
+	.slice(0, 1)
+	.forEach(link => link.focus());
 }
 
 function getSkillFromPopout(skillPopout)
@@ -4050,14 +4060,16 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 
 			suggestionMessage.textContent = messageText;
 
-			suggestionMessage.appendChild(document.createElement("a"));
-			suggestionMessage.lastChild.href = "/practice";
-			suggestionMessage.lastChild.style.color = "blue";
-			suggestionMessage.lastChild.textContent = "general practice";
-			suggestionMessage.lastChild.addEventListener("focus", focus);
-			suggestionMessage.lastChild.addEventListener("blur", blur);
-			suggestionMessage.lastChild.addEventListener("mouseenter", focus);
-			suggestionMessage.lastChild.addEventListener("mouseleave", blur);
+			const generalPracticeLink = document.createElement("a");
+			generalPracticeLink.href = "/practice";
+			generalPracticeLink.style.color = "blue";
+			generalPracticeLink.textContent = "general practice";
+			generalPracticeLink.addEventListener("focus", focus);
+			generalPracticeLink.addEventListener("blur", blur);
+			generalPracticeLink.addEventListener("mouseenter", focus);
+			generalPracticeLink.addEventListener("mouseleave", blur);
+
+			suggestionMessage.appendChild(generalPracticeLink);
 		}
 		else if (treeLevel == 0)
 		{
@@ -4135,8 +4147,6 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 	if (!document.body.contains(container))
 	{
 		topOfTree.appendChild(container);
-
-		if (options.focusFirstSkill) container.querySelector(`a`).focus();
 	}
 }
 function showOnlyNeededSkills()
@@ -4693,6 +4703,12 @@ function addFeatures()
 		{
 			// Should not be displaying a suggestion.
 			removeSuggestion() // if there happens to be one
+		}
+		
+		// Focus the fist skill of one of the lists based on the priority options
+		if (options.focusFirstSkill)
+		{
+			focusFirstSkill();
 		}
 	}
 

--- a/options.html
+++ b/options.html
@@ -362,6 +362,23 @@
 		<li>
 			<input class="option" id="focusFirstSkill" type="checkbox" checked />
 			<label for="focusFirstSkill">Focus First Skill in Lists</label>
+			<ul>
+				<li class="textOnly">
+					<span>Lists Priority for Focus</span>
+					<ul>
+						<li class="hasSelect">
+							<select class="option" id="focusPriorities">
+								<option value="ncs" selected>Needs Strengthening &gt; Cracked &gt; Suggestion</option>
+								<option value="nsc">Needs Strengthening &gt; Suggestion &gt; Cracked</option>
+								<option value="cns">Cracked &gt; Needs Strengthening &gt; Suggestion</option>
+								<option value="csn">Cracked &gt; Suggestion &gt; Needs Strengthening</option>
+								<option value="snc">Suggestion &gt; Needs Strengthening &gt; Cracked</option>
+								<option value="scn">Suggestion &gt; Cracked &gt; Needs Strengthening</option>
+							</select>
+						</li>
+					</ul>
+				</li>
+			</ul>
 		</li>
 		<li>
 			<input class="option" id="practiseButton" type="checkbox" checked />
@@ -369,7 +386,7 @@
 		</li>
 		<li class="selectFirst">
 			<select class="option selective" subOptionsEnabled="2" id="practiceType">
-				<option value="0" selected="true">Lessons (Earn Crowns)</selected>
+				<option value="0" selected>Lessons (Earn Crowns)</option>
 				<option value="1">Practice (Strengthen Only)</option>
 				<option value="2">Lessons up to Threshold</option>
 			</select>


### PR DESCRIPTION
## Added
- Sub option to the Focus First Skills Option to set the priority order for which of the lists at the top of the tree is initially focused.