### PR TITLE
Hotfix 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v2.0.1] - 2021-03-02
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.1)
+### Fixed
+- Typos in options list.
+
 [v2.0.0] - 2021-03-01
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.0)
@@ -1186,6 +1192,7 @@ Changelog
   from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v2.0.1]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.0...v2.0.1
 [v2.0.0]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.45...v2.0.0
 [v1.3.45]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.44...v1.3.45
 [v1.3.44]: https://github.com/ToranSharma/Duo-Strength/compare/v1.3.43...v1.3.44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog
 
 ### Changed
 - Focus Mode is no longer applied on pages other than the learn and tips pages.
-- Wording of the option that hides the leauge table to be in the positive sense.
+- Wording of the option that hides the league table to be in the positive sense.
 
 ### Fixed
 - Default options loading users with no saved options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.1)
 ### Added
+- Multi part option to pick the order of boxes in the sidebar.
 - Option to keep border around question text and buttons when hiding cartoons.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 [v2.0.1] - 2021-03-02
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.1)
+### Added
+- Option to keep border around question text and buttons when hiding cartoons.
+
 ### Changed
 - Focus Mode is no longer applied on pages other than the learn and tips pages.
 - Wording of the option that hides the leauge table to be in the positive sense.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changelog
 ### Changed
 - Focus Mode is no longer applied on pages other than the learn and tips pages.
 - Wording of the option that hides the league table to be in the positive sense.
+- L0 bonus skills cannot have "PRACTISE" button added, due to issue where
+  duolingo still gives out crowns after practice sessions.
 
 ### Fixed
 - Default options loading users with no saved options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.1)
 ### Changed
 - Focus Mode is no longer applied on pages other than the learn and tips pages.
+- Wording of the option that hides the leauge table to be in the positive sense.
 
 ### Fixed
 - Default options loading users with no saved options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,18 @@ Changelog
 [v2.0.1] - 2021-03-02
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.1)
+### Changed
+- Focus Mode is no longer applied on pages other than the learn and tips pages.
+
 ### Fixed
+- Default options loading users with no saved options.
 - Typos in options list.
+- Flag borders tree level extraction from progress history.
+- Show only needs attention option from trying to be applied on pages other than
+  the learn page.
+- Removal of L2 grammar skills from the skill suggestion choices on L2 trees.
+
+
 
 [v2.0.0] - 2021-03-01
 -----------------

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -72,6 +72,8 @@
 		"languagesInfoSortOrder":					"0",
 	"totalStrengthBox":							true,
 
+	"sidebarBoxOrder":							" ",
+
 
 		"showTranslationText":						true,
 		"showToggleHidingTextButton":				true,

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -82,6 +82,7 @@
 		"revealHotkeyCode":							"Ctrl+Alt+H",
 	"revealNewWordTranslation":					true,
 	"hideCartoons":								false,
+	"keepQuestionBorders":						false,
 
 	"addTipsPagePractiseButton":				true,
 	"addTipsPageBottomButtons":					true,

--- a/disabledOptions.json
+++ b/disabledOptions.json
@@ -28,6 +28,8 @@
 		"languagesInfo":							false,
 	"totalStrengthBox":							false,
 
+	"sidebarBoxOrder":							" ",
+
 	
 		"showTranslationText":						true,
 		"showToggleHidingTextButton":				false,

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -125,7 +125,7 @@ const childListObserver = new MutationObserver(childListMutationHandle);
 
 async function retrieveDefaultOptions()
 {
-	return fetch(chrome.runtime.getURL("defaultOptions.json")).then(response => response.json);
+	return fetch(chrome.runtime.getURL("defaultOptions.json")).then(response => response.json());
 }
 
 function retrieveOptions()

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -72,6 +72,10 @@ const MOBILE_TIPS_PAGE_HEADER_SELECTOR = "._36P0W";
 const CARTOON_CONTAINER = "F2B9m"; // used only in styles/stylesheet.css
 const HINT_SENTENCE_CONTAINER = "_1Q4WV"; // used only in styles/stylesheet.css
 const HINT_SENTENCE_BUBBLE_ARROW = "_3fuMA"; // used only in styles/stylesheet.css
+const AD = "_1UOwI _3bfsh";
+const ACHIEVEMENT_BOX = "Yth9H";
+const FRIENDS_TABLE_TITLE_SELECTOR = ".-AHpg";
+const SOCIAL_BUTTONS_HEADER_SELECTOR = "._3qTe3";
 
 const flagYOffsets = {
 	0:	"en", 32: "es", 64: "fr", 96: "de",
@@ -3884,6 +3888,82 @@ function fixPopoutAlignment(skillPopout)
 	skillPopout.firstChild.lastChild.removeAttribute("style");
 }
 
+function arrangeSidebarBoxOrder()
+{
+	const sidebarBoxes = Array.from(document.querySelectorAll(`.${SIDEBAR} > div`)).map(element => ({element: element, type: getSidebarBoxType(element)}));
+	sidebarBoxes.sort(sortByOrderPreference);
+	sidebarBoxes.forEach((({element, type}) => element.parentElement.appendChild(element)));
+}
+
+function getSidebarBoxType(boxElement)
+{
+	if (boxElement.contains(document.querySelector(`.${LEAGUE_TABLE}`)))
+	{
+		return "leagues";
+	}
+	if (boxElement.classList.contains(DAILY_GOAL_SIDEBAR_CONTAINER))
+	{
+		return "XPBox";
+	}
+	else if (boxElement.id === "languagesBox")
+	{
+		return "languagesBox";
+	}
+	else if (boxElement.id === "totalStrengthBox")
+	{
+		return "totalStrengthBox";
+	}
+	else if (boxElement.id === "sidebarCrownsInfoContainer")
+	{
+		return "crownsBox";
+	}
+	else if (AD.split(" ").every((classPart) => boxElement.classList.contains(classPart)))
+	{
+		return "ad";
+	}
+	else if (boxElement.classList.contains(ACHIEVEMENT_BOX))
+	{
+		return "achievementBox";
+	}
+	else if (boxElement.contains(document.querySelector(FRIENDS_TABLE_TITLE_SELECTOR)))
+	{
+		return "friendsBox";
+	}
+	else if (boxElement.contains(document.querySelector(SOCIAL_BUTTONS_HEADER_SELECTOR)))
+	{
+		return "socialButtonsBox";
+	}
+	else
+	{
+		return "unknown";
+	}
+}
+
+function sortByOrderPreference(a, b)
+{
+	const priorityA = getPriorityOfSidebarBox(a);
+	const priorityB = getPriorityOfSidebarBox(b);
+
+	return priorityA - priorityB;
+}
+
+function getPriorityOfSidebarBox(box)
+{
+	let priority = options.sidebarBoxOrder.split(",").indexOf(box.type);
+	if (priority === -1)
+	{
+		const unsortedOrder = ["leagues","XPBox","languagesBox","totalStrengthBox","crownsBox","ad","achievementBox","friendsBox","socialButtonsBox"];
+		priority = 100 + unsortedOrder.indexOf(box.type);
+	}
+
+	if (priority === 99)
+	{
+		priority = 1000;
+	}
+
+	return priority;
+}
+
 function getStrengths()
 {
 	const strengths = [[],[]]; // first array holds strengths for normal skills, second for bonus skills
@@ -4138,6 +4218,11 @@ function addFeatures()
 		{
 			removeLanguagesInfo();
 		}
+	}
+
+	// Order the Sidebar Boxes
+	{
+		arrangeSidebarBoxOrder();
 	}
 
 	// Lists of skills that need attention next

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -5160,6 +5160,10 @@ function childListMutationHandle(mutationsList, observer)
 			// Language list added, add the flag borders
 			addFlagBorders();
 		}
+
+		// One of the above may have triggered a re adding of an XP or Crowns Box.
+		// Make sure it is still in the right order.
+		arrangeSidebarBoxOrder();
 	}
 
 	if (lessonMainSectionContentsReplaced)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -3960,6 +3960,10 @@ function getSuggestion()
 		skillsByCrowns[skill.skill_progress.level].push(skill);
 	}
 
+	// Remove crown 2 grammar skills as these are at max level,
+	// so practising them will not contribute to getting to tree level 3.
+	skillsByCrowns[2] = skillsByCrowns[2].filter(skill => skill.category !== "grammar");
+
 	/*
 		0: Random
 		1: First
@@ -3977,12 +3981,6 @@ function getSuggestion()
 	}
 	else
 	{
-		if (treeLevel === 2)
-		{
-			// Remove crown 2 grammar skills as these are at max level,
-			// so practising them will not contribute to getting to tree level 3.
-			skillsByCrowns[treeLevel].filter(skill => skill.category !== "grammar");
-		}
 		const numSkillsAtTreeLevel = skillsByCrowns[treeLevel].length;
 		switch (options.skillSuggestionMethod)
 		{

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2514,7 +2514,9 @@ function addButtonsToTipsPage()
 function applyFocusMode()
 {
 	// Hide the sidebar if in focus mode.
-	if (options.focusMode && onMainPage)
+	if (
+		options.focusMode && ((new RegExp("/(learn|tips/?)")).test(window.location.pathname))
+	)
 	{
 		rootElem.classList.add("focusMode");
 	}
@@ -5170,15 +5172,15 @@ function classNameMutationHandle(mutationsList, observer)
 		// There has been a page change, either to or from the main page.
 
 
+		applyFocusMode();
+		applyFixedSidebar();
+
 		// check if we are now on the main page
 		if (window.location.pathname == "/learn")
 		{
 			// on main page
 			onMainPage = true;
 			
-			applyFocusMode();
-			applyFixedSidebar();
-
 			// check if language has been previously set as we only set it in init if we were on the main page
 			if (language != "")
 			{
@@ -5203,9 +5205,6 @@ function classNameMutationHandle(mutationsList, observer)
 			
 			// We may be on a tips page so try to add the buttons.
 			addButtonsToTipsPage();
-
-			// Don't want to be in focus mode if we aren't on the learn page
-			rootElem.classList.remove("focusMode");
 		}
 	}
 	if (questionCheckStatusChange)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -71,7 +71,7 @@ const LOCKED_SKILL_POPOUT_SELECTOR = "._1fMEX";
 const MOBILE_TIPS_PAGE_HEADER_SELECTOR = "._36P0W";
 const CARTOON_CONTAINER = "F2B9m"; // used only in styles/stylesheet.css
 const HINT_SENTENCE_CONTAINER = "_1Q4WV"; // used only in styles/stylesheet.css
-const HINT_SENTENCE_BUBBLE_ARROW = "_2nhmY"; // used only in styles/stylesheet.css
+const HINT_SENTENCE_BUBBLE_ARROW = "_3fuMA"; // used only in styles/stylesheet.css
 
 const flagYOffsets = {
 	0:	"en", 32: "es", 64: "fr", 96: "de",
@@ -5451,10 +5451,11 @@ async function init()
 			if (options.hideCartoons)
 			{
 				document.body.classList.add("hideCartoons");
+				document.body.classList[(options.keepQuestionBorders)? "add" : "remove"]("keepQuestionBorders");
 			}
 			else
 			{
-				document.body.classList.remove("hideCartoons");
+				document.body.classList.remove("hideCartoons", "keepQuestionBorders");
 			}
 
 			lastSkill = await retrieveLastSkill();

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2514,7 +2514,7 @@ function addButtonsToTipsPage()
 function applyFocusMode()
 {
 	// Hide the sidebar if in focus mode.
-	if (options.focusMode)
+	if (options.focusMode && onMainPage)
 	{
 		rootElem.classList.add("focusMode");
 	}
@@ -5203,6 +5203,9 @@ function classNameMutationHandle(mutationsList, observer)
 			
 			// We may be on a tips page so try to add the buttons.
 			addButtonsToTipsPage();
+
+			// Don't want to be in focus mode if we aren't on the learn page
+			rootElem.classList.remove("focusMode");
 		}
 	}
 	if (questionCheckStatusChange)

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -252,7 +252,7 @@ function storeTreeLevel()
 									{
 										if (Object.entries(data).length !== 0)
 										{
-											resolve(
+											resolve2(
 												Object.keys(data.progress).filter(
 													(key) =>
 													{
@@ -267,7 +267,7 @@ function storeTreeLevel()
 												)
 											);
 										}
-										resolve();
+										resolve2({});
 									}
 								);
 							}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -3687,6 +3687,10 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 
 function showOnlyNeededSkills()
 {
+	if (!onMainPage)
+	{
+		return false;
+	}
 	// Remove existing reveal button
 	document.querySelectorAll(`#revealHiddenSkillsButton`).forEach(button => button.remove());
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2261,8 +2261,16 @@ function addPractiseButton(skillPopout)
 	const skillLevel = levelContainer.textContent.slice(-3,-2);
 	const maxLevel = levelContainer.textContent.slice(-1);
 	if (skillLevel === maxLevel || (skillLevel === "0" && !options.crownZeroPractiseButton))
-		return false; // Skill is at max level so only practising is possible
+	{
+		return false;
+	}
 
+	const skillObject = getSkillFromPopout(skillPopout);
+	if (skillObject.bonus)
+	{
+		// Issue with practising L0 bonus skill, crown can still be earned.
+		return false;
+	}
 	const startButton = document.querySelector(`[data-test="start-button"]`);
 	startButton.textContent = "START LESSON";
 
@@ -2271,7 +2279,8 @@ function addPractiseButton(skillPopout)
 	practiseButton.title = "Practising this skill will strengthen it, but will not contribute any progress towards earning the next crown.";
 	practiseButton.setAttribute("data-test", "practise-button");
 
-	const urlTitle = getSkillFromPopout(skillPopout).url_title;
+
+	const urlTitle = skillObject.url_title;
 	practiseButton.addEventListener("click", (event) => {
 		const skillName = skillPopout.parentNode.querySelector(SKILL_NAME_SELECTOR).textContent;
 		const lastSkill = {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"2.0.0",
+	"version"			:	"2.0.1",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body page="0">
 	<header>
 		<h1>Duo Strength Options</h1>
-		<span id="version">v2.0.0</span>
+		<span id="version">v2.0.1</span>
 	</header>
 	<ul>
 		<li class="section">

--- a/options.html
+++ b/options.html
@@ -237,8 +237,8 @@
 					</ul>
 				</li>
 				<li class="checkboxOption">
-					<label for="showLeagues">Show League Table in Sidebar</label>
-					<input class="option" id="showLeagues" type="checkbox" />
+					<label for="showLeagues">Hide League Table in Sidebar</label>
+					<input class="option negative" id="showLeagues" type="checkbox" />
 				</li>
 				<li class="checkboxOption">
 					<label for="treeLevelBorder">Coloured Flag Border in Language List to Show Tree Level</label>

--- a/options.html
+++ b/options.html
@@ -480,7 +480,11 @@
 				</li>
 				<li class="checkboxOption">
 					<label for="hideCartoons">Hide Cartoon Characters in Lessons</label>
-					<input class="option" id="hideCartoons" type="checkbox" />
+					<input class="option" id="hideCartoons" type="checkbox" controlling='[false]:["#keepQuestionBorders"]' />
+				</li>
+				<li class="checkboxOption">
+					<label for="keepQuestionBorders">Keep Border Around Questions When Cartoons are Hidden</label>
+					<input class="option" id="keepQuestionBorders" type="checkbox" />
 				</li>
 			</ul>
 		</li>

--- a/options.html
+++ b/options.html
@@ -74,23 +74,23 @@
 						</li>
 						<li class="section">
 							<h3 class="sectionHeading">Sorting Method</h3>
-							<ul class="sectionOptionsList multiPart" id="needsStrengtheningListSortOrder">
+							<ul class="sectionOptionsList multiPart" id="needsStrengtheningListSortOrder" furtherItemCutoff="4" maxParts="3">
 								<li class="selectOption">
 									<label for="needsStrengtheningListSortOrder0">Primary</label>
 									<select class="option" id="needsStrengtheningListSortOrder0">
-										<option value="0" selected="true">Tree Order</option>
-										<option value="1">Reverse Tree Order</option>
-										<option value="2">Alphabetical</option>
-										<option value="3">Reverse Alphabetical</option>
+										<option value="0" invalidNextValues="1">Tree Order</option>
+										<option value="1" invalidNextValues="1">Reverse Tree Order</option>
+										<option value="2" invalidNextValues="3">Alphabetical</option>
+										<option value="3" invalidNextValues="2">Reverse Alphabetical</option>
 										<option value="4">Random</option>
-										<option value="5">Strength Asc.</option>
-										<option value="6">Strength Desc.</option>
-										<option value="7">Crown Level Asc.</option>
-										<option value="8">Crown Level Desc.</option>
+										<option value="5" invalidNextValues="6">Strength Asc.</option>
+										<option value="6" invalidNextValues="5">Strength Desc.</option>
+										<option value="7" invalidNextValues="8">Crown Level Asc.</option>
+										<option value="8" invalidNextValues="7">Crown Level Desc.</option>
 									</select>
 								</li>
 								<li>
-									<span class="addSortList">Add another sorting criterion</span>
+									<span class="addPart">Add another sorting criterion</span>
 								</li>
 							</ul>
 						</li>
@@ -424,6 +424,29 @@
 				<li class="checkboxOption">
 					<label for="totalStrengthBox">Total Strength Box</label>
 					<input class="option" id="totalStrengthBox" type="checkbox" />
+				</li>
+			</ul>
+		</li>
+		<li class="section">
+			<h3 class="sectionHeading">Sidebar Box Sort Order</h3>
+			<ul class="sectionOptionsList multiPart" id="sidebarBoxOrder" furtherItemCutoff=" " maxParts="9">
+				<li class="selectOption">
+					<label>Top</label>
+					<select class="option" id="sidebarBoxOrder0">
+						<option value=" ">Unchanged</option>
+						<option value="leagues" invalidNextValues=" ">League Table</option>
+						<option value="XPBox" invalidNextValues=" ">Daily Goal (XP Info)</option>
+						<option value="languagesBox" invalidNextValues=" ">Languages Info</option>
+						<option value="totalStrengthBox" invalidNextValues=" ">Total Strength Box</option>
+						<option value="crownsBox" invalidNextValues=" ">Crowns Info</option>
+						<option value="ad" invalidNextValues=" ">Advert</option>
+						<option value="achievementBox" invalidNextValues=" ">Achievements</option>
+						<option value="friendsBox" invalidNextValues=" ">Friends</option>
+						<option value="socialButtonsBox" invalidNextValues=" ">Social Media Buttons</option>
+					</select>
+				</li>
+				<li>
+					<span class="addPart">Add another box to the sort order</span>
 				</li>
 			</ul>
 		</li>

--- a/options.html
+++ b/options.html
@@ -163,7 +163,7 @@
 									<input class="option"  id="hideSuggestionNonStrengthened" type="checkbox" />
 								</li>
 								<li class="checkboxOption">
-									<label for="hideSuggestionWithCrackedSkills">Hide Suggestion When There Arre Cracked Skills</label>
+									<label for="hideSuggestionWithCrackedSkills">Hide Suggestion When There Are Cracked Skills</label>
 									<input class="option"  id="hideSuggestionWithCrackedSkills" type="checkbox" />
 								</li>
 								<li class="checkboxOption">

--- a/options.html
+++ b/options.html
@@ -29,11 +29,11 @@
 			<h3 class="sectionHeading">Mastered Skills</h3>
 			<ul class="sectionOptionsList">
 				<li class="checkboxOption">
-					<label for="ignoreMasteredSkills">Force Skills Marked as Matersted to 100% Strength</label>
+					<label for="ignoreMasteredSkills">Force Skills Marked as Mastered to 100% Strength</label>
 					<input class="option" id="ignoreMasteredSkills" type="checkbox" controlling='[false]:["#masteredButton"]' />
 				</li>
 				<li class="checkboxOption">
-					<label for="masteredButton">Add Button to Mark Skills as mastered in Skill Popouts</label>
+					<label for="masteredButton">Add Button to Mark Skills as Mastered in Skill Popouts</label>
 					<input class="option" id="masteredButton" type="checkbox" />
 				</li>
 				<li class="button">

--- a/styles/options.css
+++ b/styles/options.css
@@ -368,14 +368,14 @@ li.selectOption
 	align-items: center;
 }
 
-.addSortList
+.addPart
 {
 	display: block;
 	padding: 0.5rem;
 	cursor: pointer;
 	position: relative;
 }
-.addSortList::after
+.addPart::after
 {
 	content:"+";
 	position: absolute;
@@ -385,7 +385,7 @@ li.selectOption
 	font-size: 1.5rem;
 	color: var(--contrast);
 }
-.addSortList:active::after
+.addPart:active::after
 {
 	transform: translateY(-50%) scale(0.8);
 }

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -845,8 +845,11 @@
 	visibility: hidden !important;
 }
 
-.hideCartoons [data-test~="challenge"] ._1Q4WV, /* HINT_SENTENCE_CONTAINER */
-.hideCartoons [data-test~="challenge"] ._2nhmY /* HINT_SENTENCE_BUBBLE_ARROW*/
+.hideCartoons:not(.keepQuestionBorders) [data-test~="challenge"] ._1Q4WV /* HINT_SENTENCE_CONTAINER */
 {
 	border: none !important;
+}
+.hideCartoons [data-test~="challenge"] ._3fuMA /* HINT_SENTENCE_BUBBLE_ARROW*/
+{
+	display: none;
 }


### PR DESCRIPTION
### Added
- Multi part option to pick the order of boxes in the sidebar.
- Option to keep border around question text and buttons when hiding cartoons.

### Changed
- Focus Mode is no longer applied on pages other than the learn and tips pages.
- Wording of the option that hides the league table to be in the positive sense.

### Fixed
- Default options loading users with no saved options.
- Typos in options list.
- Flag borders tree level extraction from progress history.
- Show only needs attention option from trying to be applied on pages other than
  the learn page.
- Removal of L2 grammar skills from the skill suggestion choices on L2 trees.