### PR TITLE
Hotfix 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Changelog
 ------------
 -
 
+[v2.0.7] - 2021-07-21
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.7)
+### Removed
+- Checking of old key format for progress history storage. All instances of
+  this should have already been caught and updated to the new user id based
+  format.
+
 [v2.0.6] - 2021-07-04
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.6)
@@ -1267,6 +1275,7 @@ Changelog
   from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v2.0.7]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.6...v2.0.7
 [v2.0.6]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.5...v2.0.6
 [v2.0.5]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.4...v2.0.5
 [v2.0.4]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.3...v2.0.4

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -4894,6 +4894,11 @@ function hideTranslationText(reveal = false, setupObserver = true)
 			document.body.classList.remove("blurringSentence");
 		}
 	}
+	else
+	{
+		// Not a translating type question of any sort, so make sure the text is displaying if there is any.
+		document.body.classList.remove("blurringSentence");
+	}
 	return false;
 }
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -172,7 +172,6 @@ function retrieveProgressHistory()
 		chrome.storage.sync.get("progress", function (data)
 		{
 			const key = `${userId}:${UICode}->${languageCode}`;
-			const oldFormatKey = username + languageCode + UICode;
 			if (Object.entries(data).length === 0)
 			{
 				// No progress data
@@ -182,14 +181,6 @@ function retrieveProgressHistory()
 			{
 				// There is some data for the current user+tree combination
 				progress = data.progress[key];
-			}
-			else if (data.progress.hasOwnProperty(oldFormatKey))
-			{
-				// There is data in the old format, we will use this data but remove the old format
-				progress = [...data.progress[oldFormatKey]]; // Copy the data as we are going to delete it
-				data.progress[key] = progress;
-				delete data.progress[oldFormatKey];
-				chrome.storage.sync.set({"progress": data.progress});
 			}
 			else
 			{

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"2.0.6",
+	"version"			:	"2.0.7",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body page="0">
 	<header>
 		<h1>Duo Strength Options</h1>
-		<span id="version">v2.0.6</span>
+		<span id="version">v2.0.7</span>
 	</header>
 	<ul>
 		<li class="section">


### PR DESCRIPTION
### Removed
- Checking of old key format for progress history storage. All instances of this should have already been caught and updated to the new user id based format.