### PR TITLE
Hotfix 2.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changelog
   - Maximum crown count calculation updated to account for legendary skills.
   - Crowns breakdown table now includes legendary level.
   - Test out button being added to L2 grammar skills.
+  - Maximum value for lesson threshold option to 5.
+    - With this option set to 5, L5 skill links in at the top of the tree will
+      practice and not point to the legendary test (the default behaviour).
 
 ### Added
 - New flag border colour and legendary crown logo for L6 trees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 - Issues with new legendary skills.
   - Skill list links point to practice if skill is legendary.
     - L5 normal skills, L2 grammar skills and L1 bonus skill links point to the
-      legendary test. The lingot cost is ignored.
+      legendary test.
   - Practise button adding handles new crown level option.
   - Tips page practice button adding.
   - Maximum crown count calculation updated to account for legendary skills.
@@ -21,8 +21,6 @@ Changelog
 
 ### Added
 - New flag border colour and legendary crown logo for L6 trees.
-- Option to remove the lingot cost of the legendary button in skill popouts.
-  - Enabled by default.
 - Option to add a legendary button to the top the tips page of skills of the
   correct level.
   - Enabled by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Changelog
 - Issues with new legendary skills.
   - Skill list links point to practice if skill is >= L5.
   - Practise button adding handles new crown level option.
+  - Tips page practice button adding.
   - Maximum crown count calculation updated to account for legendary skills.
   - Crowns breakdown table now includes legendary level.
+  - Test out button being added to L2 grammar skills.
 
 [v2.0.12] - 2021-09-11
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Changelog
 ### Added
 - New flag border colour and legendary crown logo for L6 trees.
 - Option to remove the lingot cost of the legendary button in skill popouts.
+  - Enabled by default.
+- Option to add a legendary button to the top the tips page of skills of the
+  correct level.
+  - Enabled by default.
 
 [v2.0.12] - 2021-09-11
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.13)
 ### Fixed
 - Issues with new legendary skills.
-  - Skill list links point to practice if skill is >= L5.
+  - Skill list links point to practice if skill is legendary.
+    - L5 normal skills, L2 grammar skills and L1 bonus skill links point to the
+      legendary test. The lingot cost is ignored.
   - Practise button adding handles new crown level option.
   - Tips page practice button adding.
   - Maximum crown count calculation updated to account for legendary skills.
@@ -19,6 +21,7 @@ Changelog
 
 ### Added
 - New flag border colour and legendary crown logo for L6 trees.
+- Option to remove the lingot cost of the legendary button in skill popouts.
 
 [v2.0.12] - 2021-09-11
 -----------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Changelog
 ------------
 -
 
+[v2.0.13] - 2021-09-23
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.13)
+### Fixed
+- Issues with new legendary skills.
+  - Skill list links point to practice if skill is >= L5.
+  - Practise button adding handles new crown level option.
+  - Maximum crown count calculation updated to account for legendary skills.
+  - Crowns breakdown table now includes legendary level.
+
 [v2.0.12] - 2021-09-11
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.12)
@@ -1308,6 +1318,7 @@ Changelog
   from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v2.0.13]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.12...v2.0.13
 [v2.0.12]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.11...v2.0.12
 [v2.0.11]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.10...v2.0.11
 [v2.0.10]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.9...v2.0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changelog
   - Crowns breakdown table now includes legendary level.
   - Test out button being added to L2 grammar skills.
 
+### Added
+- New flag border colour and legendary crown logo for L6 trees.
+
 [v2.0.12] - 2021-09-11
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.12)

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -92,6 +92,7 @@
 
 	"practiseButton":							true,
 	"crownZeroPractiseButton":					false,
+	"removeLegendaryCost":						true,
 	"wordsButton":								true,
 	"grammarSkillsTestButton":					true,
 

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -88,6 +88,7 @@
 	"keepQuestionBorders":						false,
 
 	"addTipsPagePractiseButton":				true,
+	"legendaryTipsPageButton":					true,
 	"addTipsPageBottomButtons":					true,
 
 	"practiseButton":							true,

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -93,7 +93,6 @@
 
 	"practiseButton":							true,
 	"crownZeroPractiseButton":					false,
-	"removeLegendaryCost":						true,
 	"wordsButton":								true,
 	"grammarSkillsTestButton":					true,
 

--- a/disabledOptions.json
+++ b/disabledOptions.json
@@ -40,6 +40,7 @@
 	"addTipsPageBottomButtons":					false,
 
 	"practiseButton":							false,
+	"removeLegendaryCost":						false,
 	"wordsButton":								false,
 	"grammarSkillsTestButton":					false,
 

--- a/disabledOptions.json
+++ b/disabledOptions.json
@@ -37,6 +37,7 @@
 	"hideCartoons":								false,
 
 	"addTipsPagePractiseButton":				false,
+	"legendaryTipsPageButton":					false,
 	"addTipsPageBottomButtons":					false,
 
 	"practiseButton":							false,

--- a/disabledOptions.json
+++ b/disabledOptions.json
@@ -41,7 +41,6 @@
 	"addTipsPageBottomButtons":					false,
 
 	"practiseButton":							false,
-	"removeLegendaryCost":						false,
 	"wordsButton":								false,
 	"grammarSkillsTestButton":					false,
 

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -853,7 +853,7 @@ function progressMadeBetweenPoints(startIndex, endIndex)
 
 function currentTreeLevel()
 {
-	const skillsByCrowns = Array(7).fill([]);
+	const skillsByCrowns = Array(7).fill(null).map(item => []);
 
 	userData.language_data[languageCode].skills.forEach(
 		(skill) =>
@@ -862,8 +862,8 @@ function currentTreeLevel()
 		}
 	);
 
-	// Remove grammar skills from L2 skills array as they are at max level so should not hold the tree level back.
-	skillsByCrowns[2] = skillsByCrowns[2].filter(skill => skill.category !== "grammar");
+	// Remove grammar skills from L3 skills array as they are at max level so should not hold the tree level back.
+	skillsByCrowns[3] = skillsByCrowns[3].filter(skill => skill.category !== "grammar");
 
 	let treeLevel = 0;
 	while (skillsByCrowns[treeLevel].length === 0 && treeLevel < skillsByCrowns.length)
@@ -4096,7 +4096,7 @@ function getSuggestion()
 
 	const skills = userData.language_data[languageCode].skills;
 	const treeLevel = currentTreeLevel();
-	let skillsByCrowns = Array(7).fill([]);
+	let skillsByCrowns = Array(7).fill(null).map(item => []);
 
 	for (let skill of skills)
 	{

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2075,9 +2075,9 @@ function addGrammarSkillTestOutButton(skillPopout)
 
 	// Skill popout is a grammar skill and there isn't a test out button
 
-	if (skillData.skill_progress.level === skillData.num_levels) return false;
+	if (skillData.skill_progress.level >= 2) return false;
 
-	// Not at max level so can test out.
+	// At a level for which you can test out to the next one.
 
 	const testOutButton = addSmallButtonToPopout(skillPopout, true);
 	testOutButton.setAttribute("data-test", "test-out-button");
@@ -2458,7 +2458,7 @@ function addButtonsToTipsPage()
 			const toPractise = skillObject.skill_progress.level >= 5
 							|| (
 								skillObject.category === "grammar"
-								&& skillObject.skill_progress.level === 2
+								&& skillObject.skill_progress.level >= 2
 							)
 							|| (
 								skillObject.bonus && skillObject.skill_progress.level >= 1

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -7,8 +7,10 @@ const PURPLE = "rgb(206, 130, 255)";
 const GREY = "rgb(229, 229, 229)";
 const DARK_BLUE = "rgb(24, 153, 214)";
 const LIGHT_BLUE = "rgb(28, 176, 246)";
+const LEGENDARY_PURPLE = "rgb(169, 161, 255)";
 
 const imgSrcBaseUrl = "//d35aaqx5ub95lt.cloudfront.net/images";
+const legendaryCrownPath = "crowns/dc4851466463c85bbfcaaaaae18e1925";
 
 // Duolingo class names:
 const BONUS_SKILL_DIVIDER_SELECTOR = "._3Sis0";
@@ -1430,7 +1432,14 @@ function addFlagBorders()
 						if (treeLevel === 5)
 						{
 							const crown = document.createElement("IMG");
-							crown.src = imgSrcBaseUrl+"/juicy-crown.svg";
+							crown.src = `${imgSrcBaseUrl}/juicy-crown.svg`;
+                            flag1.parentNode.classList.add("flagContainer")
+							flag1.parentNode.appendChild(crown);
+						}
+						if (treeLevel === 6)
+						{
+							const crown = document.createElement("IMG");
+							crown.src = `${imgSrcBaseUrl}/${legendaryCrownPath}.svg`;
                             flag1.parentNode.classList.add("flagContainer")
 							flag1.parentNode.appendChild(crown);
 						}
@@ -3182,7 +3191,7 @@ function displayCrownsBreakdown()
 					else
 					{
 						imgContainer.lastChild.textContent = "";
-						imgContainer.firstChild.src = `${imgSrcBaseUrl}/crowns/dc4851466463c85bbfcaaaaae18e1925.svg`;
+						imgContainer.firstChild.src = `${imgSrcBaseUrl}/${legendaryCrownPath}.svg`;
 					}
 
 					let breakdownListItem = document.createElement("li");

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2508,12 +2508,36 @@ function addButtonsToTipsPage()
 							|| (
 								skillObject.bonus && skillObject.skill_progress.level === 2
 							);
+			
+			const legendaryNext = skillObject.skill_progress.level === 5
+							|| (
+								skillObject.category === "grammar"
+								&& skillObject.skill_progress.level === 2
+							)
+							|| (
+								skillObject.bonus && skillObject.skill_progress.level === 1
+							);
 
 			const startLessonButton = startLessonButtons[0];
 			startLessonButton.parentNode.classList.add("tipsPageButtonContainer");
 			startLessonButton.parentNode.id = "tipsPageTopContainer";
+
+			if (options.legendaryTipsPageButton && legendaryNext)
+			{
+				// The start button is actually a practise button, but there could be a legendary button.
+				// Let's change this button into a legendary button.
+				// The click handler will be added after we have the correct number of buttons.
+				startLessonButton.setAttribute("data-test", "final-button");
+				startLessonButton.textContent = "legendary";
+				const legendaryCrownImg = document.createElement("img");
+				legendaryCrownImg.src = `${imgSrcBaseUrl}/${legendaryCrownPath}.svg`;
+				legendaryCrownImg.classList.add("legendaryCrownImg");
+				startLessonButton.insertBefore(legendaryCrownImg, startLessonButton.firstChild);
+			}
+
 			// Add the practise button at the top if it is wanted.
-			if (options.addTipsPagePractiseButton && !toPractise)
+			
+			if (options.addTipsPagePractiseButton && !(toPractise || (legendaryNext && !options.legendaryTipsPageButton)))
 			{
 				const practiseButton = startLessonButton.cloneNode(true);
 				practiseButton.setAttribute("data-test", "practise-button");
@@ -2539,31 +2563,51 @@ function addButtonsToTipsPage()
 				);
 			}
 
-			// Add click handler to practise buttons
+			// Add click handler to practise buttons.
 			document.querySelectorAll(`[data-test="practise-button"]`).forEach(
 				(practiseButton) =>
 				{
+					practiseButton.href = `/skill/${languageCode}/${skillUrlTitle}/practice`;
 					practiseButton.addEventListener("click",
 						(event) =>
 						{
+							event.preventDefault();
 							window.location.pathname = `/skill/${languageCode}/${skillUrlTitle}/practice`;
 						}
 					);
 				}
 			);
 
-			// click handler to second start-lesson button
+			// Add click handler for legendary buttons.
+			Array.from(document.querySelectorAll(`[data-test="final-button"]`)).forEach(
+				(legendaryButton) =>
+				{
+					legendaryButton.href = `/skill/${languageCode}/${skillUrlTitle}`;
+					legendaryButton.addEventListener("click",
+						(event)=>
+						{
+							event.preventDefault();
+							window.location.pathname = `/skill/${languageCode}/${skillUrlTitle}`;
+						}
+					);
+				}
+			);
+
+			// Add click handler to button start-lesson button.
 			Array.from(document.querySelectorAll(`[data-test="start-lesson"]`)).slice(1).forEach(
 				(startButton) =>
 				{
+					startButton.href = `/skill/${languageCode}/${skillUrlTitle}${toPractise ? "/practice" : ""}`;
 					startButton.addEventListener("click",
 						(event)=>
 						{
+							event.preventDefault();
 							window.location.pathname = `/skill/${languageCode}/${skillUrlTitle}${toPractise ? "/practice" : ""}`;
 						}
 					);
 				}
 			);
+
 		}
 	}
 	else

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -851,7 +851,7 @@ function progressMadeBetweenPoints(startIndex, endIndex)
 
 function currentTreeLevel()
 {
-	const skillsByCrowns = [[],[],[],[],[],[]];
+	const skillsByCrowns = Array(7).fill([]);
 
 	userData.language_data[languageCode].skills.forEach(
 		(skill) =>
@@ -864,7 +864,7 @@ function currentTreeLevel()
 	skillsByCrowns[2] = skillsByCrowns[2].filter(skill => skill.category !== "grammar");
 
 	let treeLevel = 0;
-	while (skillsByCrowns[treeLevel].length === 0 && treeLevel < 6)
+	while (skillsByCrowns[treeLevel].length === 0 && treeLevel < skillsByCrowns.length)
 	{
 		treeLevel++;
 	}
@@ -1852,10 +1852,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][i];
 
 			const toPractise =
-				skill.skill_progress.level === 5
+				skill.skill_progress.level >= 5
 				|| options.practiceType === "1"
 				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 2);
+				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1865,7 +1865,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			let bonusSkillIndex = i - needsStrengthening[0].length;
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level === 1)? "/practice":""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level >= 1)? "/practice":""}`;
 			skillLink.textContent = skill.short;
 		}
 
@@ -1909,10 +1909,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][needsStrengthening[0].length -1];
 
 			const toPractise =
-				skill.skill_progress.level === 5
+				skill.skill_progress.level >= 5
 				|| options.practiceType === "1"
 				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 2);
+				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1934,10 +1934,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][lastIndexToBeShown];
 
 			const toPractise =
-				skill.skill_progress.level === 5
+				skill.skill_progress.level >= 6
 				|| options.practiceType === "1"
 				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 2);
+				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1947,7 +1947,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			let bonusSkillIndex = lastIndexToBeShown - needsStrengthening[0].length;
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level === 1)? "/practice":""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level >= 1)? "/practice":""}`;
 			skillLink.textContent = skill.short;
 		}
 		strengthenBox.appendChild(skillLink);
@@ -2247,12 +2247,21 @@ function addPractiseButton(skillPopout)
 	
 	const levelContainer = document.querySelector(SKILL_POPOUT_LEVEL_CONTAINER_SELECTOR);
 	if (levelContainer === null)
-		return false; // Locked skill so don't do anything
+		return false; // Locked skill so don't do anything.
 
-	const skillLevel = levelContainer.textContent.slice(-3,-2);
-	const maxLevel = levelContainer.textContent.slice(-1);
-	if (skillLevel === maxLevel || (skillLevel === "0" && !options.crownZeroPractiseButton))
+	if (levelContainer.textContent.slice(-2,-1) === "/")
 	{
+		// Skill is <= L4.
+		const skillLevel = levelContainer.textContent.slice(-3,-2);
+		const maxLevel = levelContainer.textContent.slice(-1);
+		if (skillLevel === maxLevel || (skillLevel === "0" && !options.crownZeroPractiseButton))
+		{
+			return false;
+		}
+	}
+	else
+	{
+		// Skill is L5 or L6 and so there is already a "practice" button.
 		return false;
 	}
 
@@ -2446,13 +2455,13 @@ function addButtonsToTipsPage()
 								.find(skill => skill.url_title === skillUrlTitle);
 
 			// See if this skill is at max crown level so the start-lesson button will be point to a practice sesison.
-			const toPractise = skillObject.skill_progress.level === 5
+			const toPractise = skillObject.skill_progress.level >= 5
 							|| (
 								skillObject.category === "grammar"
 								&& skillObject.skill_progress.level === 2
 							)
 							|| (
-								skillObject.bonus && skillObject.skill_progress.level === 1
+								skillObject.bonus && skillObject.skill_progress.level >= 1
 							);
 
 			const startLessonButton = startLessonButtons[0];
@@ -2815,7 +2824,7 @@ function displayCrownsBreakdown()
 	const bonusSkills = userData.language_data[languageCode].bonus_skills;
 	const grammarSkills = userData.language_data[languageCode].skills.filter(skill => skill.category === "grammar");
 
-	let crownLevelCount = [Array(6).fill(0),Array(2).fill(0),Array(3).fill(0)]; // will hold number skills at each crown level, index 0 : crown 0 (not finished), index 1 : crown 1, etc.
+	let crownLevelCount = [Array(7).fill(0), Array(3).fill(0), Array(4).fill(0)]; // will hold number skills at each crown level, index 0 : crown 0 (not finished), index 1 : crown 1, etc.
 	// crownLevelCount[0] normal skills
 	// crownLevelCount[1] bonus skills
 	// crownLevelCount[2] grammar skills
@@ -2835,7 +2844,7 @@ function displayCrownsBreakdown()
 		crownLevelCount[2][grammarSkill.skill_progress.level]++;
 	}
 
-	const maxCrownCount = 5*skills.length + 2*grammarSkills.length + bonusSkills.length;
+	const maxCrownCount = 6*skills.length + 2*bonusSkills.length + 3*grammarSkills.length;
 
 	const treeLevel = currentTreeLevel();
 
@@ -3163,8 +3172,18 @@ function displayCrownsBreakdown()
 
 					const crownCount = skillCount * crownLevel;
 				
-					imgContainer.lastChild.classList.add("crownLevel" + crownLevel + "Count");
-					imgContainer.lastChild.textContent = crownLevel;
+					imgContainer.lastChild.classList.remove(`crownLevel${(crownLevel-1) % (crownLevelCount[skillType].length)}Count`);
+					imgContainer.lastChild.classList.add(`crownLevel${crownLevel}Count`);
+					if (crownLevel < crownLevelCount[skillType].length - 1)
+					{
+						imgContainer.lastChild.textContent = crownLevel;
+						imgContainer.firstChild.src = `${imgSrcBaseUrl}/juicy-crown.svg`;
+					}
+					else
+					{
+						imgContainer.lastChild.textContent = "";
+						imgContainer.firstChild.src = `${imgSrcBaseUrl}/crowns/dc4851466463c85bbfcaaaaae18e1925.svg`;
+					}
 
 					let breakdownListItem = document.createElement("li");
 					breakdownListItem.classList.add("crownLevelItem");
@@ -3212,7 +3231,7 @@ function displayCrownsBreakdown()
 			}
 
 			// Tree Level prediction
-			if (treeLevel != 5 && options.treeLevelPrediction)
+			if (treeLevel != 6 && options.treeLevelPrediction)
 			{
 				const predictionData = (progress.length > 5) ? daysToNextTreeLevel() : daysToNextTreeLevelByCalendar();
 
@@ -3223,7 +3242,7 @@ function displayCrownsBreakdown()
 				}
 			}
 			
-			if (treeLevel === 5)
+			if (treeLevel === 6)
 			{
 				const maxLevelMessage = document.createElement("p");
 				maxLevelMessage.classList.add("treeLevelPrediction");
@@ -3571,7 +3590,7 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 
 		if (suggestedSkill !== null)
 		{
-			const toPractise = treeLevel === 5 || (suggestedSkill.category === "grammar" && suggestedSkill.skill_progress.level === 2);
+			const toPractise = treeLevel >= 5 || (suggestedSkill.category === "grammar" && suggestedSkill.skill_progress.level >= 2);
 
 			link.href = `/skill/${languageCode}/${suggestedSkill.url_title}${toPractise ? "/practice/" : "/"}`;
 			link.textContent = suggestedSkill.short;
@@ -3599,13 +3618,13 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 		link.addEventListener("mouseenter", focus);
 		
 		const suggestionMessage = document.createElement("p");
-		if (treeLevel === 5)
+		if (treeLevel === 6)
 		{
 			let messageText = `Your ${language} tree is `;
 			if (fullyStrengthened)
 				messageText += "fully strengthened and ";
 			
-			messageText += "at Level 5";
+			messageText += "at Level 6";
 
 			if (noCrackedSkills)
 				messageText += " with no cracked skills";
@@ -3659,7 +3678,7 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 		}
 		else
 		{
-			// Not level 5 or level 0 so we will use the suggestion based on the users options.
+			// Not level 6 or level 0 so we will use the suggestion based on the users options.
 			if (fullyStrengthened && noCrackedSkills)
 				suggestionMessage.textContent = `Your ${language} tree is fully strengthened, and there are no cracked cracked skills. `;
 			else if (fullyStrengthened)
@@ -4068,7 +4087,7 @@ function getSuggestion()
 
 	const skills = userData.language_data[languageCode].skills;
 	const treeLevel = currentTreeLevel();
-	let skillsByCrowns = [[],[],[],[],[],[]];
+	let skillsByCrowns = Array(7).fill([]);
 
 	for (let skill of skills)
 	{
@@ -4090,7 +4109,7 @@ function getSuggestion()
 		// Tree isn't finished, so we will just suggest the first skill
 		suggestedSkill = skillsByCrowns[0][0];
 	}
-	else if (treeLevel === 5)
+	else if (treeLevel === 6)
 	{
 		suggestedSkill = null;
 	}

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2311,42 +2311,6 @@ function addPractiseButton(skillPopout)
 	skillPopout.scrollIntoView({block: "center"});
 }
 
-function modifyLegendaryButton(skillPopout)
-{
-	if (skillPopout === null)
-		return false;
-
-	let legendaryButton = skillPopout.querySelector(`[data-test="final-button"]`);
-	if (legendaryButton === null)
-	{
-		return false;
-	}
-	
-	const skillObject = getSkillFromPopout(skillPopout);
-	const urlTitle = skillObject.url_title;
-
-	// replace the button with a custom clone.
-	const clone = legendaryButton.cloneNode(true);
-	legendaryButton.replaceWith(clone);
-	legendaryButton = clone;
-
-	legendaryButton.addEventListener("click",
-		(event) =>
-		{
-			event.preventDefault();
-			const skillName = skillPopout.parentNode.querySelector(SKILL_NAME_SELECTOR).textContent;
-			const lastSkill = {
-				skillName: skillName,
-				urlTitle: urlTitle
-			};
-
-			chrome.storage.sync.set({lastSkill: lastSkill});
-
-			window.location = `/skill/${languageCode}/${urlTitle}`;
-		}
-	);
-}
-
 function addCheckpointButtons(checkpointPopout, completedMessage = false)
 {
 	// Check popout is still there
@@ -4444,15 +4408,14 @@ function addFeatures()
 			removeWordsButton();
 			removeMasteredSkillButton();
 
-			if (options.practiseButton || options.removeLegendaryCost)
+			if (options.practiseButton)
 			{
 				// Want practise button and there isn't one.
 				const introLesson = document.querySelector(`[data-test="intro-lesson"]`);
 				if (introLesson === null || !introLesson.contains(skillPopout))
 				{
 					// No introduction lesson, or if there is this skillPopout isn't from that skill
-					if (options.practiseButton) addPractiseButton(skillPopout);
-					if (options.removeLegendaryCost) modifyLegendaryButton(skillPopout);
+					addPractiseButton(skillPopout);
 				}
 			}
 
@@ -5363,7 +5326,6 @@ function childListMutationHandle(mutationsList, observer)
 		{
 			// No introduction lesson, or if there is this skillPopout isn't from that skill
 			if (options.practiseButton) addPractiseButton(skillPopout);
-			if (options.removeLegendaryCost) modifyLegendaryButton(skillPopout);
 		}
 
 		if (options.grammarSkillsTestButton) addGrammarSkillTestOutButton(skillPopout);

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -5817,25 +5817,50 @@ The structure of page is as follows:
 															</div>
 														</div>
 													######## Only after clicking a skill ###################################################################
-													#	<div class="_33-99" data-test="skill-popout">                        <-- Popout container
-													#		<div class="_3tWnW _3_Gei _1W3aa _1kf1N">
-													#			<div class="_1b8Ja _1GJUD _3lagd SSzTP _1JPPG">
-													#				<div class="_1cv-y">                                     <-- Small buttons container
+													#	<div class="_3uS_y eIZ_c" data-test="skill-popout">                  <-- Popout container
+													#		<div class="_2O14B _2XlFZ _1v2Gj WCcVn" style="z-index: 1;">
+													#			<div class="_1KUxv _1GJUD _3lagd _2FApd">
+													#				<div class="_34eBb _1kWrO">                              <-- Crowns progress graphic holder
+													#					<div class="_2-dXY">								 <-- Crown image holder
+													#						<img alt="crown" class="_18sNN"                  <-- Crown image
+													#							 src="....../crowns/f2e84728e922b45ed79761f3f5002166.svg"
+													#							 style="height: 38px; width: 38px;">
+													#						<div class="GkDDe" data-test="level-crown">1</div>
+													#					</div>
+													#					<div class="_2-dXY">...</div>
+													#					<div class="_2-dXY">...</div>
+													#					<div class="_2-dXY">...</div>
+													#					<div class="_2-dXY">...</div>
+													#					<div class="_2-dXY">								 <-- Crown image holder
+													#						<img alt="crown" class="_18sNN"                  <-- Legendary Crown image
+													#							 src="....../crowns/00ef38a541ef4b6a08f1108991ecfd92.svg"
+													#							 style="height: 38px; width: 38px;">
+													#					</div>
+													#				</div>
+													#				<div class="_1cv-y smallButtonsContainer">               <-- Small buttons container
+													#					######################################               <-- Mastered skill button goes here
 													#					######################################               <-- Words list button goes here
-													#					<button>...</button>                                 <-- Test out button
+													#					<a class="_3zRHo WOZnx _275sd _1ZefG _3nfx7"
+													#					   data-test="test-out-button"
+													#					   href="/skill/${languageCode}/${skill.url_title}/test">...</a> <-- Test out button
 													#				</div>
-													#				<div class="_1cv-y"></div>
-													#				<div class="QowCP">
-													#					<div class="_1m77f">Level x/5</div>
-													#					<div class="_3L5UX">Lesson y / z</div>
-													#				</div>
+													#				<div class="_1m77f">Level x/6</div>
+													#				<div class="RXDIm">Lesson y/z</div>
 													#				<div class="_2I_Id">
-													#					<button class="_2aoiN _1HSlC _2C1GY _2gwtT _1nlVc _2fOC9 t5wFJ _3dtSu _25Cnc _3yAjN _226dU _1figt" data-test="tips-button">Tips</button>
-													#					<button class="twkSI _25Mqa whuSQ _2gwtT _1nlVc _2fOC9 t5wFJ _3dtSu _25Cnc _3yAjN UCrz7 yTpGk" data-test="start-button">Start Lesson</button>
+													#					<a class="_3zRHo WOZnx _275sd _1ZefG _2aoiN _1eyFy" data-test="tips-button" href="/skill/${languageCode}/${skill.url_title}/tips">Tips</a>
+													#					<a class="twkSI _1eyFy _25Mqa whuSQ _2gwtT _1nlVc _2fOC9 t5wFJ _3dtSu _25Cnc _3yAjN UCrz7 yTpGk" data-test="start-button" href="/skill/es/Intro/1">START LESSON</a>
+													#					#####################################                <-- Practise Button goes here
+													#				####### If skill is level 5 ##############################################################
+													#				#	<button class="_3HhhB _2NolF _275sd _1ZefG _26hHl _1eyFy _26QYy" data-test="final-button">
+													#				#		<img class="eoQRg _13HXc" src="....../crowns/dc4851466463c85bbfcaaaaae18e1925.svg">
+													#				#		<span class="_13HXc">Legendary</span>
+													#				#	</button>
+													#				##########################################################################################
 													#				</div>
-													#				#####################################                    <-- Practise Button goes here
+													#			</div>                                                       <-- Popout bubble arrow
+													#			<div class="ite_X">
+													#				<div class="_3p5e9 _3lagd _2FApd"></div>
 													#			</div>
-													#			<div class="_37dAC">...</div>                                <-- Popout bubble arrow
 													#		</div>
 													#	</div>
 													########################################################################################################

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1861,10 +1861,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][i];
 
 			const toPractise =
-				skill.skill_progress.level >= 5
+				skill.skill_progress.level === 6
 				|| options.practiceType === "1"
-				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
+				|| (options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
+				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1874,7 +1874,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			let bonusSkillIndex = i - needsStrengthening[0].length;
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level >= 1)? "/practice":""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level == 2)? "/practice":""}`;
 			skillLink.textContent = skill.short;
 		}
 
@@ -1910,7 +1910,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			// last skill to be displayed is a bonus skill
 			const skill = needsStrengthening[1][needsStrengthening[1].length -1];
 
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level === 1)? "/practice":""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level === 2)? "/practice":""}`;
 			skillLink.textContent = skill.short;
 		} else
 		{
@@ -1918,10 +1918,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][needsStrengthening[0].length -1];
 
 			const toPractise =
-				skill.skill_progress.level >= 5
+				skill.skill_progress.level === 6
 				|| options.practiceType === "1"
 				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
+				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1943,10 +1943,10 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			const skill = needsStrengthening[0][lastIndexToBeShown];
 
 			const toPractise =
-				skill.skill_progress.level >= 6
+				skill.skill_progress.level === 6
 				|| options.practiceType === "1"
 				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level >= 2);
+				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
 
 			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
@@ -1956,7 +1956,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			let bonusSkillIndex = lastIndexToBeShown - needsStrengthening[0].length;
 			const skill = needsStrengthening[1][bonusSkillIndex];
 
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level >= 1)? "/practice":""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${(skill.skill_progress.level === 2)? "/practice":""}`;
 			skillLink.textContent = skill.short;
 		}
 		strengthenBox.appendChild(skillLink);
@@ -2311,6 +2311,42 @@ function addPractiseButton(skillPopout)
 	skillPopout.scrollIntoView({block: "center"});
 }
 
+function modifyLegendaryButton(skillPopout)
+{
+	if (skillPopout === null)
+		return false;
+
+	let legendaryButton = skillPopout.querySelector(`[data-test="final-button"]`);
+	if (legendaryButton === null)
+	{
+		return false;
+	}
+	
+	const skillObject = getSkillFromPopout(skillPopout);
+	const urlTitle = skillObject.url_title;
+
+	// replace the button with a custom clone.
+	const clone = legendaryButton.cloneNode(true);
+	legendaryButton.replaceWith(clone);
+	legendaryButton = clone;
+
+	legendaryButton.addEventListener("click",
+		(event) =>
+		{
+			event.preventDefault();
+			const skillName = skillPopout.parentNode.querySelector(SKILL_NAME_SELECTOR).textContent;
+			const lastSkill = {
+				skillName: skillName,
+				urlTitle: urlTitle
+			};
+
+			chrome.storage.sync.set({lastSkill: lastSkill});
+
+			window.location = `/skill/${languageCode}/${urlTitle}`;
+		}
+	);
+}
+
 function addCheckpointButtons(checkpointPopout, completedMessage = false)
 {
 	// Check popout is still there
@@ -2464,13 +2500,13 @@ function addButtonsToTipsPage()
 								.find(skill => skill.url_title === skillUrlTitle);
 
 			// See if this skill is at max crown level so the start-lesson button will be point to a practice sesison.
-			const toPractise = skillObject.skill_progress.level >= 5
+			const toPractise = skillObject.skill_progress.level === 6
 							|| (
 								skillObject.category === "grammar"
-								&& skillObject.skill_progress.level >= 2
+								&& skillObject.skill_progress.level === 3
 							)
 							|| (
-								skillObject.bonus && skillObject.skill_progress.level >= 1
+								skillObject.bonus && skillObject.skill_progress.level === 2
 							);
 
 			const startLessonButton = startLessonButtons[0];
@@ -3599,7 +3635,7 @@ function displaySuggestion(fullyStrengthened, noCrackedSkills)
 
 		if (suggestedSkill !== null)
 		{
-			const toPractise = treeLevel >= 5 || (suggestedSkill.category === "grammar" && suggestedSkill.skill_progress.level >= 2);
+			const toPractise = treeLevel === 6 || (suggestedSkill.category === "grammar" && suggestedSkill.skill_progress.level === 3);
 
 			link.href = `/skill/${languageCode}/${suggestedSkill.url_title}${toPractise ? "/practice/" : "/"}`;
 			link.textContent = suggestedSkill.short;
@@ -4364,14 +4400,15 @@ function addFeatures()
 			removeWordsButton();
 			removeMasteredSkillButton();
 
-			if (options.practiseButton)
+			if (options.practiseButton || options.removeLegendaryCost)
 			{
 				// Want practise button and there isn't one.
 				const introLesson = document.querySelector(`[data-test="intro-lesson"]`);
 				if (introLesson === null || !introLesson.contains(skillPopout))
 				{
 					// No introduction lesson, or if there is this skillPopout isn't from that skill
-					addPractiseButton(skillPopout);
+					if (options.practiseButton) addPractiseButton(skillPopout);
+					if (options.removeLegendaryCost) modifyLegendaryButton(skillPopout);
 				}
 			}
 
@@ -5282,6 +5319,7 @@ function childListMutationHandle(mutationsList, observer)
 		{
 			// No introduction lesson, or if there is this skillPopout isn't from that skill
 			if (options.practiseButton) addPractiseButton(skillPopout);
+			if (options.removeLegendaryCost) modifyLegendaryButton(skillPopout);
 		}
 
 		if (options.grammarSkillsTestButton) addGrammarSkillTestOutButton(skillPopout);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"2.0.12",
+	"version"			:	"2.0.13",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body page="0">
 	<header>
 		<h1>Duo Strength Options</h1>
-		<span id="version">v2.0.12</span>
+		<span id="version">v2.0.13</span>
 	</header>
 	<ul>
 		<li class="section">

--- a/options.html
+++ b/options.html
@@ -538,8 +538,16 @@
 					<input class="option" id="practiseButton" type="checkbox" data-controlling='[false]:["#crownZeroPractiseButton"]'/>
 				</li>
 				<li class="checkboxOption">
+					<label for="removeLegendaryCost">Practise Button</label>
+					<input class="option" id="removeLegendaryCost" type="checkbox" />
+				</li>
+				<li class="checkboxOption">
 					<label for="crownZeroPractiseButton">Practise Button on Crown 0 Skills</label>
 					<input class="option" id="crownZeroPractiseButton" type="checkbox" />
+				</li>
+				<li class="checkboxOption">
+					<label for="removeLegendaryCost">Remove Lingot Cost from Legendary Button</label>
+					<input class="option" id="removeLegendaryCost" type="checkbox" />
 				</li>
 				<li class="checkboxOption">
 					<input class="option" id="wordsButton" type="checkbox" />

--- a/options.html
+++ b/options.html
@@ -525,6 +525,10 @@
 					<input class="option" id="addTipsPagePractiseButton" type="checkbox" />
 				</li>
 				<li class="checkboxOption">
+					<label for="legendaryTipsPageButton">Add Legendary Button at the Top Of the Tips if Skill is the Correct Level</label>
+					<input class="option" id="legendaryTipsPageButton" type="checkbox" />
+				</li>
+				<li class="checkboxOption">
 					<label for="addTipsPageBottomButtons">Add Second Set of Buttons at the Bottom of the Tips</label>
 					<input class="option" id="addTipsPageBottomButtons" type="checkbox" />
 				</li>

--- a/options.html
+++ b/options.html
@@ -542,10 +542,6 @@
 					<input class="option" id="practiseButton" type="checkbox" data-controlling='[false]:["#crownZeroPractiseButton"]'/>
 				</li>
 				<li class="checkboxOption">
-					<label for="removeLegendaryCost">Remove Lingot Cost of Legendary Button</label>
-					<input class="option" id="removeLegendaryCost" type="checkbox" />
-				</li>
-				<li class="checkboxOption">
 					<label for="crownZeroPractiseButton">Practise Button on Crown 0 Skills</label>
 					<input class="option" id="crownZeroPractiseButton" type="checkbox" />
 				</li>

--- a/options.html
+++ b/options.html
@@ -542,7 +542,7 @@
 					<input class="option" id="practiseButton" type="checkbox" data-controlling='[false]:["#crownZeroPractiseButton"]'/>
 				</li>
 				<li class="checkboxOption">
-					<label for="removeLegendaryCost">Practise Button</label>
+					<label for="removeLegendaryCost">Remove Lingot Cost of Legendary Button</label>
 					<input class="option" id="removeLegendaryCost" type="checkbox" />
 				</li>
 				<li class="checkboxOption">

--- a/options.html
+++ b/options.html
@@ -199,7 +199,7 @@
 				</li>
 				<li class="numberOption">
 					<label for="lessonThreshold" class="greaterThan">Practice on Skills with Crown Level <span>&ge;</span></label>
-					<input class="option" id="lessonThreshold" type="number" value="4" min="1" max="4" />
+					<input class="option" id="lessonThreshold" type="number" value="4" min="1" max="5" />
 				</li>
 			</ul>
 		</li>

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -775,8 +775,18 @@
 {
 	margin-left: 1em;
 }
+.tipsPageButtonContainer [data-test="final-button"]
+{
+	color: var(--legendary-purple);
+}
+.tipsPageButtonContainer [data-test="final-button"] .legendaryCrownImg
+{
+	width: 34px;
+	margin: -8px 0.5em -34px 0;
+	transform: translateY(-50%);
+}
 
-#tipsPageTopContainer *:first-child
+#tipsPageTopContainer > *:first-child
 {
 	margin-right: auto;
 }

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -9,6 +9,7 @@
 	--grey: rgb(229, 229, 229);
 	--dark-blue: rgb(24, 153, 214);
 	--light-blue: rgb(28, 176, 246);
+	--legendary-purple: rgb(169, 161, 255);
 }
 
 
@@ -714,7 +715,11 @@
 {
 	border-color: var(--gold);
 }
-.borderedFlag[data-tree-level="5"] ~ img
+.borderedFlag[data-tree-level="6"]
+{
+	border-color: var(--legendary-purple);
+}
+.borderedFlag ~ img
 {
 	position: absolute;
 	left: 5px;


### PR DESCRIPTION
### Fixed
- Issues with new legendary skills.
  - Skill list links point to practice if skill is legendary.
    - L5 normal skills, L2 grammar skills and L1 bonus skill links point to the legendary test.
  - Practise button adding handles new crown level option.
  - Tips page practice button adding.
  - Maximum crown count calculation updated to account for legendary skills.
  - Crowns breakdown table now includes legendary level.
  - Test out button being added to L2 grammar skills.

### Added
- New flag border colour and legendary crown logo for L6 trees.
- Option to add a legendary button to the top the tips page of skills of the
  correct level.
  - Enabled by default.
- Maximum value for lesson threshold option to 5.
  - With this option set to 5, L5 skill links in at the top of the tree will practice and not point to the legendary test (the default behaviour).