### PR TITLE
Hotfix 2.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 ------------
 -
 
+[v2.0.15] - 2021-09-26
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.15)
+### Fixed
+- Focus mode button click behaviour.
+
 [v2.0.14] - 2021-09-24
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.14)
@@ -1337,6 +1343,7 @@ Changelog
   from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v2.0.15]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.14...v2.0.15
 [v2.0.14]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.13...v2.0.14
 [v2.0.13]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.12...v2.0.13
 [v2.0.12]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.11...v2.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Changelog
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.15)
 ### Fixed
 - Focus mode button click behaviour.
+- Link session type threshold option.
+
+### Added
+- Options to control the link behaviour of L5 skills in the Needs Strengthening
+  List and Cracked Skills separately. By default this option is disabled
+  meaning links point to legendary tests rather than practice sessions.
 
 [v2.0.14] - 2021-09-24
 -----------------

--- a/defaultOptions.json
+++ b/defaultOptions.json
@@ -13,15 +13,17 @@
 
 		"needsStrengtheningList":					true,
 		"needsStrengtheningListLength":				"10",
-		"needsStrengtheningListSortOrder":			"0",
 		"showBonusSkillsInNeedsStrengtheningList":	true,
 		"needsStrengtheningPopoutButton":			true,
+		"practiseL5NeedsStrengtheningSkills":		false,
+		"needsStrengtheningListSortOrder":			"0",
 
 		"crackedSkillsList":						true,
 		"crackedSkillsListLength":					"10",
-		"crackedSkillsListSortOrder":				"0",
 		"showBonusSkillsInCrackedSkillsList":		true,
 		"crackedPopoutButton":						true,
+		"crackedSkillsListSortOrder":				"0",
+		"practiseL5CrackedSkills":					false,
 
 		"skillSuggestion":							true,
 		"skillSuggestionMethod":					"0",

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -1843,6 +1843,16 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 		}
 	};
 
+	const toPractise = (skill) =>
+	{
+		return skill.skill_progress.level === 6
+				|| options.practiceType === "1"
+				|| (options.practiceType === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
+				|| (skill.category === "grammar" && skill.skill_progress.level === 3)
+				|| (cracked && options.practiseL5CrackedSkills)
+				|| (!cracked && options.practiseL5NeedsStrengtheningSkills);
+	};
+
 	let numSkillsToShow = Math.min(numSkillsToBeStrengthened, (!cracked)?options.needsStrengtheningListLength:options.crackedSkillsListLength);
 	for (let i = 0; i < numSkillsToShow - 1; i++)
 	{
@@ -1855,13 +1865,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			// index is in normal skill range
 			const skill = needsStrengthening[0][i];
 
-			const toPractise =
-				skill.skill_progress.level === 6
-				|| options.practiceType === "1"
-				|| (options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
-
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise(skill) ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
 		} else
 		{
@@ -1912,13 +1916,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			// last skill to be displayed is a normal skill
 			const skill = needsStrengthening[0][needsStrengthening[0].length -1];
 
-			const toPractise =
-				skill.skill_progress.level === 6
-				|| options.practiceType === "1"
-				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
-
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise(skill) ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
 		}
 		
@@ -1937,13 +1935,7 @@ function displayNeedsStrengthening(needsStrengthening, cracked = false, needsSor
 			// index is in normal skill range
 			const skill = needsStrengthening[0][lastIndexToBeShown];
 
-			const toPractise =
-				skill.skill_progress.level === 6
-				|| options.practiceType === "1"
-				|| ( options.practice === "2" && skill.skill_progress.level.toString() >= options.lessonThreshold)
-				|| (skill.category === "grammar" && skill.skill_progress.level === 3);
-
-			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise ? "/practice" : ""}`;
+			skillLink.href = `/skill/${languageCode}/${skill.url_title}${toPractise(skill) ? "/practice" : ""}`;
 			skillLink.textContent = skill.short;
 		} else
 		{

--- a/duoStrength.js
+++ b/duoStrength.js
@@ -2618,7 +2618,6 @@ function applyFocusMode()
 		&& globalPractiseButtonContainer !== null 
 	)
 	{
-
 		const focusModeButton = globalPractiseButtonContainer.cloneNode(true);
 		focusModeButton.id = "focusModeButton";
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"2.0.14",
+	"version"			:	"2.0.15",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body page="0">
 	<header>
 		<h1>Duo Strength Options</h1>
-		<span id="version">v2.0.14</span>
+		<span id="version">v2.0.15</span>
 	</header>
 	<ul>
 		<li class="section">

--- a/options.html
+++ b/options.html
@@ -70,6 +70,10 @@
 									<label for="needsStrengtheningPopoutButton">Skill Popout Button for Links</label>
 									<input class="option"  id="needsStrengtheningPopoutButton" type="checkbox" />
 								</li>
+								<li class="checkboxOption">
+									<label for="practiseL5NeedsStrengtheningSkills">Link to Practice Session for L5 Skills</label>
+									<input class="option"  id="practiseL5NeedsStrengtheningSkills" type="checkbox" />
+								</li>
 							</ul>
 						</li>
 						<li class="section">
@@ -131,6 +135,10 @@
 										<option value="3">Reverse Alphabetical</option>
 										<option value="4">Random</option>
 									</select>
+								</li>
+								<li class="checkboxOption">
+									<label for="practiseL5CrackedSkills">Link to Practice Session for L5 Skills</label>
+									<input class="option"  id="practiseL5CrackedSkills" type="checkbox" />
 								</li>
 							</ul>
 						</li>

--- a/styles/stylesheet.css
+++ b/styles/stylesheet.css
@@ -745,13 +745,7 @@
 {
 	margin-left: auto;
 	margin-right: 0;
-	height: 0;
 }
-[data-test="focusModeButton"]
-{
-	transform: translateY(-100%);
-}
-
 
 /* Fixed Sidebar */
 


### PR DESCRIPTION
### Fixed
- Focus mode button click behaviour.
- Link session type threshold option.

### Added
- Options to control the link behaviour of L5 skills in the Needs Strengthening List and Cracked Skills separately. By default this option is disabled meaning links point to legendary tests rather than practice sessions.