### PR TITLE
Fixed Japanese Language support with stories.

### DIFF
--- a/duoStrength.js
+++ b/duoStrength.js
@@ -5542,6 +5542,14 @@ function setUpObservers()
 			crownNav = topBarDiv.childNodes[11];
 			streakNav = topBarDiv.childNodes[12];
 		}
+		// Languages with characters and stories (e.g. Japanese)
+		else if (numNavButtons === 6) { 
+			storiesNav = topBarDiv.childNodes[4];
+			shopNav = topBarDiv.childNodes[8];
+			languageLogo = topBarDiv.childNodes[12];
+			crownNav = topBarDiv.childNodes[13];
+			streakNav = topBarDiv.childNodes[14];
+		}
 		else
 		{
 			/* unused/unusable


### PR DESCRIPTION
Duolingo added Japanese language stories on Oct 27th, 2021, and it also has character, breaking duo strengths.