### PR TITLE
Hotfix 2.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog
 ------------
 -
 
+[v2.0.21] - 2021-11-05
+-----------------
+[GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.21)
+### Removed
+- Option to remove lingot cost of legendary button. This option was added in
+  error and had no corresponding functionality in the content script.
+
 [v2.0.20] - 2021-10-28
 -----------------
 [GitHub Release Page](https://github.com/ToranSharma/Duo-Strength/releases/tag/v2.0.20)
@@ -1406,6 +1413,7 @@ Changelog
   from a lesson to the main page.
 
 [Unreleased]: https://github.com/ToranSharma/Duo-Strength/compare/master...develop
+[v2.0.21]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.20...v2.0.21
 [v2.0.20]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.19...v2.0.20
 [v2.0.19]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.18...v2.0.19
 [v2.0.18]: https://github.com/ToranSharma/Duo-Strength/compare/v2.0.17...v2.0.18

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Duo Strength",
 	"description"		:	"Adds individual skill strengths back into the duolingo webpage, similar to data on duome.eu",
-	"version"			:	"2.0.20",
+	"version"			:	"2.0.21",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -580,10 +580,6 @@
 					<input class="option" id="crownZeroPractiseButton" type="checkbox" />
 				</li>
 				<li class="checkboxOption">
-					<label for="removeLegendaryCost">Remove Lingot Cost from Legendary Button</label>
-					<input class="option" id="removeLegendaryCost" type="checkbox" />
-				</li>
-				<li class="checkboxOption">
 					<input class="option" id="wordsButton" type="checkbox" />
 					<label for="wordsButton">Words Button</label>
 				</li>

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body page="0">
 	<header>
 		<h1>Duo Strength Options</h1>
-		<span id="version">v2.0.20</span>
+		<span id="version">v2.0.21</span>
 	</header>
 	<ul>
 		<li class="section">


### PR DESCRIPTION
### Removed
- Option to remove lingot cost of legendary button. This option was added in error and had no corresponding functionality in the content script.